### PR TITLE
Add cross browser shims file

### DIFF
--- a/app/assets/stylesheets/_shims.scss
+++ b/app/assets/stylesheets/_shims.scss
@@ -1,0 +1,37 @@
+/* Cross-browser shims
+
+  Ways of normalising properties across browsers.
+ */
+@import "_conditionals";
+
+// From: https://blog.mozilla.org/webdev/2009/02/20/cross-browser-inline-block/
+
+/* Usage:
+   @include inline-block
+
+   or
+
+   @include inline-block("250px")
+
+   which gives a min-height to the inline-block elements.
+*/
+
+@mixin inline-block($min-height: "") {
+  display: -moz-inline-stack;
+  display: inline-block;
+
+  @if $min-height != "" {
+    min-height: $min-height;
+  }
+
+  @include ie-lte(7) {
+    zoom: 1;
+    display: inline;
+  }
+
+  @include ie(6) {
+    @if $min-height != "" {
+      height: $min-height;
+    }
+  }
+}


### PR DESCRIPTION
This file currently includes a helper for normalising inline-block across browsers. It takes an optional min-height argument.

Going forward cross-browser shims should also go into the new `_shims.scss` introduced by this pull request.
