### PR TITLE
Guard for when footer doesn't exist

### DIFF
--- a/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
@@ -23,10 +23,15 @@
     _els: [],
 
     addEl: function($fixedEl, height){
+      var footer = $('#footer');
+      if (footer.length === 0) {
+        return;
+      }
+
       var fixedOffset = parseInt($fixedEl.css('top'), 10);
       fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset;
 
-      stopScrollingAtFooter.footerTop = $('#footer').offset().top - 10;
+      stopScrollingAtFooter.footerTop = footer.offset().top - 10;
 
       var $siblingEl = $('<div></div>');
       $siblingEl.insertBefore($fixedEl);


### PR DESCRIPTION
This arose when working on whitehall and seeing a javascript error due
to the use of slimmer_test without a #footer element. See the pivotal
bug for more info:

https://www.pivotaltracker.com/story/show/37971541
