### PR TITLE
Remove -box suffix on box-sizing mixin

### DIFF
--- a/app/assets/stylesheets/_css3.scss
+++ b/app/assets/stylesheets/_css3.scss
@@ -38,7 +38,7 @@
 }
 
 @mixin box-sizing($type) { // Acceptable values are border, content, and padding - content is the default W3C model
-  -webkit-box-sizing: #{$type}-box;
-     -moz-box-sizing: #{$type}-box;
-          box-sizing: #{$type}-box;
+  -webkit-box-sizing: #{$type};
+     -moz-box-sizing: #{$type};
+          box-sizing: #{$type};
 }


### PR DESCRIPTION
I think you should pass the full box-sizing model through as an argument as it closer to the actual CSS command and also allows for potential future models that do not use the -box suffix
