### PR TITLE
Use an event for page resize.

### DIFF
--- a/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
@@ -27,6 +27,7 @@
       fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset;
 
       stopScrollingAtFooter.updateFooterTop();
+      $(root).on('govuk.pageSizeChanged', stopScrollingAtFooter.updateFooterTop);
 
       var $siblingEl = $('<div></div>');
       $siblingEl.insertBefore($fixedEl);
@@ -91,4 +92,6 @@
   };
 
   root.GOVUK.stopScrollingAtFooter = stopScrollingAtFooter;
+
+  $(root).load(function(){ $(root).trigger('govuk.pageSizeChanged'); });
 }).call(this);


### PR DESCRIPTION
Use an event to trigger page size change which stop scrolling at footer can listen to. This lets us decouple the code more and will allow other things to listen in also.

Also has a minor bug fix which caused the box to assume the wrong position when the footer had been reached.
