### PR TITLE
Fix media queries

### DIFF
--- a/app/assets/stylesheets/_conditionals.scss
+++ b/app/assets/stylesheets/_conditionals.scss
@@ -33,11 +33,11 @@ $is-ie: false !default;
     }
   } @else {
     @if $size == desktop {
-      @media (min-width: 768px){
+      @media (min-width: 769px){
         @content;
       }
     } @else if $size == tablet {
-      @media (min-width: 640px){
+      @media (min-width: 641px){
         @content;
       }
     } @else if $size == mobile {


### PR DESCRIPTION
Fix media query min width sizes as they were 1px out. These means that `@import media(tablet)` rules now actually work on iPad, etc
