### PR TITLE
Add appearance vendor prefix mixin

### DIFF
--- a/app/assets/stylesheets/_css3.scss
+++ b/app/assets/stylesheets/_css3.scss
@@ -38,7 +38,12 @@
 }
 
 @mixin box-sizing($type) { // Acceptable values are border, content, and padding - content is the default W3C model
-  -webkit-box-sizing: #{$type};
-     -moz-box-sizing: #{$type};
-          box-sizing: #{$type};
+  -webkit-box-sizing: $type;
+     -moz-box-sizing: $type;
+          box-sizing: $type;
+}
+
+@mixin appearance($appearance) {
+  -webkit-appearance: $appearance;
+     -moz-appearance: $appearance;
 }


### PR DESCRIPTION
These rules are outside of the CSS3 spec, and therefore don't have a non-prefixed version

http://css-tricks.com/almanac/properties/a/appearance/
