### PR TITLE
Add bold mixins

### DIFF
--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -152,6 +152,46 @@ $is-print: false !default;
   }
 }
 
+@mixin bold-80($line-height: (80 / 80), $line-height-640: (55 / 53)) {
+  @include core-80($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-48($line-height: (50 / 48), $line-height-640: (35 / 32)) {
+  @include core-48($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-36($line-height: (40 / 36), $line-height-640: (25 / 24)) {
+  @include core-36($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-27($line-height: (30 / 27), $line-height-640: (20 / 18)) {
+  @include core-27($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-24($line-height: (30 / 24), $line-height-640: (24 / 20)) {
+  @include core-24($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-19($line-height: (25 / 19), $line-height-640: (20 / 16)) {
+  @include core-19($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-16($line-height: (20 / 16), $line-height-640: (16 / 14)) {
+  @include core-16($line-height, $line-height-640);
+  font-weight: 700;
+}
+
+@mixin bold-14($line-height: (20 / 14), $line-height-640: (15 / 12)) {
+  @include core-14($line-height, $line-height-640);
+  font-weight: 700;
+}
+
 @mixin heading-80 {
   @include core-80;
 


### PR DESCRIPTION
Just adding bold versions of the core styles for now, haven't changed `font-weight` on heading styles as I don't want to impact any existing styles, use `font-weight: 700` in your local heading style to add bold weights to headings.

The bold styles will require you to have the `bold-font` branch in `static` checked out
