### PR TITLE
updating DCMS colour class name

### DIFF
--- a/app/assets/stylesheets/_colours.scss
+++ b/app/assets/stylesheets/_colours.scss
@@ -14,7 +14,7 @@ $ministry-of-defence: #4d2942;
 $foreign-and-commonwealth-office: #003e74;
 $department-for-communities-and-local-government: #00857e;
 $department-of-energy-climate-change: #009ddb;
-$department-for-culture-media-and-sport: #d40072;
+$department-for-culture-media-sport: #d40072;
 $department-for-environment-food-and-rural-affairs: #898700;
 $department-for-work-and-pensions: #00beb7;
 $department-for-business-innovation-and-skills: #003479;


### PR DESCRIPTION
Removed 'and-' to match the class name generated on the frontend. So DCMS will adopt the correct colour.
