### PR TITLE
Remove pointer to local NTA-light

### DIFF
--- a/app/assets/stylesheets/_font_stack.scss
+++ b/app/assets/stylesheets/_font_stack.scss
@@ -12,17 +12,9 @@
 
 // New Transport Light
 
-@font-face {
-  font-family: GDS-Regular;
-  src: local("HelveticaNeue"),
-       local("Helvetica Neue"),
-       local("Arial"),
-       local("Helvetica");
-}
-
 $NTA-Light:
   "nta", 
-  "GDS-Regular", 
+  Arial,
   sans-serif;
 
 // Helvetica Regular


### PR DESCRIPTION
Fix for printing issues with the Google Chrome browser, as listed on story 44184493

The story came out of the incidents in this problem: https://govuk.zendesk.com/tickets/40736

We can replicate the problem in 3 of the versions tested. In 2 of these, removing the reference to the local version of the font solves it. While this does not solve the problem completely, it does in the newest versions tested and the reference is no longer required in production.
