### PR TITLE
Add ability to take beta-notice as footer mark

### DIFF
--- a/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/app/assets/javascripts/govuk/stop-scrolling-at-footer.js
@@ -45,8 +45,7 @@
       stopScrollingAtFooter.initTimeout();
     },
     updateFooterTop: function(){
-      var $betaNotice = $('.js-footer'),
-          footer = ($betaNotice.length) ? $betaNotice : $('#footer');
+      var footer = $('.js-footer:eq(0)');
       if (footer.length === 0) {
         return 0;
       }


### PR DESCRIPTION
The second of the two new beta banners is positioned over the footer.

This change allows the sticky-scrolling JavaScript to recognise the banner as its lowest point when present.

The JavaScript relies on the elements it makes sticky to have a correct initial top position so shouldn't be merged until the CSS that does that is (see https://github.com/alphagov/static/pull/184)
