### PR TITLE
Update colours to the lastest from brand guidance

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -2,31 +2,32 @@
 // http://alphagov.github.com/design/gov.uk.colours/
 
 // Departmental colours
-$hm-government: #0076c0;
-$treasury: #af292e;
+$attorney-generals-office: #002663;
 $cabinet-office: #005abb;
-$department-for-education: #003a69;
-$department-for-transport: #006c56;
-$home-office: #9325b2;
-$department-of-health: #00ad93;
-$ministry-of-justice: #231f20;
-$ministry-of-defence: #4d2942;
-$foreign-and-commonwealth-office: #003e74;
+$department-for-business-innovation-skills: #003479;
 $department-for-communities-and-local-government: #00857e;
-$department-of-energy-climate-change: #009ddb;
 $department-for-culture-media-sport: #d40072;
-$department-for-environment-food-and-rural-affairs: #898700;
-$department-for-work-and-pensions: #00beb7;
-$department-for-business-innovation-and-skills: #003479;
+$department-for-education: #003a69;
+$department-for-environment-food-rural-affairs: #898700;
 $department-for-international-development: #002878;
+$department-for-transport: #006c56;
+$department-for-work-pensions: #00beb7;
+$department-of-energy-climate-change: #009ddb;
+$department-of-health: #00ad93;
+$foreign-commonwealth-office: #003e74;
 $government-equalities-office: #9325b2;
-$attorney-generals-office: #9f1888;
-$scotland-office: #112148;
-$wales-office: #a33038;
+$hm-government: #0076c0;
+$hm-treasury: #af292e;
+$home-office: #9325b2;
+$ministry-of-defence: #4d2942;
+$ministry-of-justice: #231f20;
 $northern-ireland-office: #002663;
+$office-of-the-advocate-general-for-scotland: #002663;
 $office-of-the-leader-of-the-house-of-lords: #9c132e;
+$scotland-office: #002663;
 // Note: the 'the' part here will get dropped
 $the-office-of-the-leader-of-the-house-of-commons: #0080bc;
+$wales-office: #a33038;
 
 // Standard palette, colours
 $purple: #2e358b;


### PR DESCRIPTION
Lots of this is just sorting the list alphabetically. However these are
the actual changes that aren't just hex updates:
- department-for-business-innovation-skills: new slug removing 'and'
- department-for-environment-food-rural-affairs: new slug removing 'and'
- department-for-work-pensions: new slug removing 'and'
- foreign-commonwealth-office: new slug removing 'and'
- hm-treasury: new slug adding 'hm'
- office-of-the-advocate-general-for-scotland: added

These are the departments with new hex values:
- attorney-generals-office
- scotland-office
