### PR TITLE
Remove Arial from font stack

### DIFF
--- a/stylesheets/_font_stack.scss
+++ b/stylesheets/_font_stack.scss
@@ -13,8 +13,7 @@
 // New Transport Light
 
 $NTA-Light:
-  "nta", 
-  Arial,
+  "nta",
   sans-serif;
 
 // Helvetica Regular


### PR DESCRIPTION
Arial isn't as pretty as Helvetica. If the NTA font doesn't load or your system doesn't support it the font will now fall-back to your system sans-serif.
