### PR TITLE
[cc] fixed the import references in the buttons design pattern

### DIFF
--- a/stylesheets/design-patterns/_buttons.scss
+++ b/stylesheets/design-patterns/_buttons.scss
@@ -1,6 +1,6 @@
-@import '_shims.scss';
-@import '_css3.scss';
-@import '_conditionals.scss';
+@import '../shims';
+@import '../css3';
+@import '../conditionals';
 
 /*
 


### PR DESCRIPTION
This resolved the error but the links to the scss files.

It seems you guys reference partials in other places using the "_" and include ".scss" extension.  Is this for an implementation in Java?  I normally don't bother.
