### PR TITLE
Add Sass compilation tips to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In development:
 
 In production:
 
-    sass --style compressed --load-path ./path/to/assets/toolkit input.scss output.css
+    sass --style compressed --load-path [path to]/govuk_toolkit/stylesheets input.scss output.css
 
 
 


### PR DESCRIPTION
Gives the same format for your output Sass as [Sass-Rails](https://github.com/rails/sass-rails) and means you don't need to change the `@import`'s in the toolkit to include relative paths.
