### PR TITLE
add a JS widget for counting down remaining chars as user types

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,30 @@ page. It can be included with the asset_pipeline by adding the line:
 
     //=require govuk_toolkit
 
+### Textarea Character Countdown
+
+#### Description
+
+As the user is typing in a textbox or textarea, this jQuery plugin updates a label with the remaining number of allowed characters.
+
+#### Usage
+
+Run this on document ready:
+
+    GOVUK.textareaCharacterCountdown.initialize($textarea, $statusArea, 1000);
+
+To customise or i18nalise the status message, override the "messageBeforeUserHasTypedAnything" and "messageAsUserIsTyping" variables with strings containing #max-num and #remaining-num placeholders.
+
+For example, for Russian i18n:
+
+    GOVUK.textareaCharacterCountdown.messageBeforeUserHasTypedAnything = "(ограничение - #max-num знаков)"
+    GOVUK.textareaCharacterCountdown.messageAsUserIsTyping = "Остается #remaining-num знаков (ограничение - #max-num знаков)";
+
+#### Parameters
+
+`$textarea` is the jQuery element into which the user types
+`$statusArea` is the jQuery element which displays the remaining # of chars
+
 ## Licence
 
 Released under the MIT Licence, a copy of which can be found in the file `LICENCE`.

--- a/javascripts/govuk/textarea-character-countdown.js
+++ b/javascripts/govuk/textarea-character-countdown.js
@@ -1,0 +1,56 @@
+// As the user is typing in a textbox or textarea, a label updates with the remaining number of allowed characters.
+//
+// Usage example (run this on document ready):
+//
+//    GOVUK.textareaCharacterCountdown.initialize($textarea, $statusArea, 1000);
+//
+// where
+//    $textarea is the jQuery element into which the user types
+//    $statusArea is the jQuery element which displays the remaining # of chars
+//
+// i18n:
+//
+// To customise or i18nalise the status message, override the "messageBeforeUserHasTypedAnything"
+// and "messageAsUserIsTyping" variables with strings containing #max-num and #remaining-num placeholders.
+// For example, for Russian i18n:
+//
+//    GOVUK.textareaCharacterCountdown.messageBeforeUserHasTypedAnything = "(ограничение - #max-num знаков)"
+//    GOVUK.textareaCharacterCountdown.messageAsUserIsTyping = "Остается #remaining-num знаков (ограничение - #max-num знаков)";
+
+
+(function () {
+  "use strict"
+  var root = this,
+      $ = root.jQuery;
+  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var textareaCharacterCountdown = {
+    initialize: function ($elementToMonitor, $remainingCharactersStatus, maximumCharacterNumber) {
+      // initial setup
+      textareaCharacterCountdown.update($remainingCharactersStatus, $elementToMonitor.text().length, maximumCharacterNumber);
+
+      $elementToMonitor.on('input', function () {
+        this.onkeydown = null;
+        textareaCharacterCountdown.update($remainingCharactersStatus, this.value.length, maximumCharacterNumber);
+      });
+
+      $elementToMonitor.on('keydown', function () {
+        textareaCharacterCountdown.update($remainingCharactersStatus, this.value.length, maximumCharacterNumber);
+      });
+    },
+    update: function ($remainingCharactersStatus, typedCharacterNumber, maximumCharacterNumber) {
+      var message;
+      if (typedCharacterNumber === 0) {
+          message = textareaCharacterCountdown.messageBeforeUserHasTypedAnything.replace("#max-num", maximumCharacterNumber);
+      } else {
+          var numberRemaining = maximumCharacterNumber - typedCharacterNumber;
+          message = textareaCharacterCountdown.messageAsUserIsTyping.replace("#max-num", maximumCharacterNumber).replace("#remaining-num", numberRemaining);
+      }
+      $remainingCharactersStatus.html(message);
+    },
+    messageBeforeUserHasTypedAnything: "(Limit is #max-num characters)",
+    messageAsUserIsTyping: "#remaining-num characters remaining (limit is #max-num characters)"
+  };
+
+  root.GOVUK.textareaCharacterCountdown = textareaCharacterCountdown;
+}).call(this);

--- a/spec/TextareaCharacterCountdownSpec.js
+++ b/spec/TextareaCharacterCountdownSpec.js
@@ -1,0 +1,47 @@
+FORM_TEXT = '<textarea></textarea><p id="status-area">some text</p>';
+
+describe("textarea character countdown", function () {
+  var $textarea, $statusArea;
+
+  beforeEach(function() {
+    setFixtures(FORM_TEXT);
+    $textarea = $('textarea');
+    $statusArea = $('#status-area');
+
+    GOVUK.textareaCharacterCountdown.initialize($textarea, $statusArea, 1000);
+  });
+
+  it("should initialise to show the maximum", function () {
+    expect($statusArea.html()).toEqual('(Limit is 1000 characters)');
+  });
+
+  it("should update to show the remaining characters when something is typed in the text area", function() {
+    $textarea.val("aa");
+    $textarea.trigger(jQuery.Event( 'keydown', { which: 'a' } ));
+
+    expect($statusArea.html()).toEqual('998 characters remaining (limit is 1000 characters)');
+  });
+
+  describe("i18n", function () {
+    beforeEach(function() {
+      setFixtures(FORM_TEXT);
+      $textarea = $('textarea');
+      $statusArea = $('#status-area');
+      GOVUK.textareaCharacterCountdown.messageBeforeUserHasTypedAnything = "(ограничение - #max-num знаков)"
+      GOVUK.textareaCharacterCountdown.messageAsUserIsTyping = "Остается #remaining-num знаков (ограничение - #max-num знаков)";
+
+      GOVUK.textareaCharacterCountdown.initialize($textarea, $statusArea, 1000);
+    });
+
+    it("should initialise to show the maximum", function () {
+      expect($statusArea.html()).toEqual('(ограничение - 1000 знаков)');
+    });
+
+    it("should update to show the remaining characters when something is typed in the text area", function() {
+      $textarea.val("aa");
+      $textarea.trigger(jQuery.Event( 'keydown', { which: 'a' } ));
+
+      expect($statusArea.html()).toEqual('Остается 998 знаков (ограничение - 1000 знаков)');
+    });
+  });
+});


### PR DESCRIPTION
This is already used in the [feedback app](https://github.com/alphagov/feedback), will also be used in [frontend](https://github.com/alphagov/frontend).

This commit also includes jasmine tests, although at this moment in time, there isn't a jasmine harness to run them yet.
