### PR TITLE
Simplify install by using local Grunt installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-before_script:
-  - npm install -g grunt-cli@0.1.11

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ To update the toolkit to the latest version you can use:
 
 Install Node 0.8 or higher and PhantomJS.
 
-    $ sudo npm install -g grunt-cli@0.1.11
     $ npm install
-    $ grunt test
+    $ npm test
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "jquery-browser": "~1.7.2-3"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "node_modules/.bin/grunt test"
   }
 }


### PR DESCRIPTION
Local Grunt was added in 438beae6410a3a1489530c16124cc0b5bcb23142 . This will simplify the process of just running tests. If you want to use grunt without having to type node_modules/.bin/grunt, you can just run:

```
$ npm install -g grunt-cli
```
