### PR TITLE
Added details to allow project to be easily included in PHP/Composer projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ follow the [installation instructions][toolkit_gem_github_readme].
 [toolkit_npm_github]: https://github.com/alphagov/govuk_frontend_toolkit_npm
 [toolkit_npm]: https://npmjs.org/package/govuk_frontend_toolkit
 
+### Composer/Symfony
+
+This repository is a component-installer component. Simply add it to your composer.json
+
+```bash
+composer require alphagov/govuk_frontend_toolkit:dev-master
+```
+
+See the [component-installer](https://github.com/RobLoach/component-installer) project for more details.
+
 ### Other projects
 
 You can include the toolkit as a [git submodule][].

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "alphagov/govuk_frontend_toolkit",
+    "description": "A collection of Sass and Javascript tools for generating frontend code.",
+    "type": "component",
+    "extra": {
+        "component": {
+            "scripts": [
+                "javascripts/**.js"
+            ],
+            "styles": [
+                "stylesheets/**.scss"
+            ],
+            "files" : [
+                "images/**/*"
+            ]
+        }
+    },
+    "require": {
+        "robloach/component-installer": "*"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,187 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "9b6f6fd797c0698316aba34dc7cfa0bd",
+    "packages": [
+        {
+            "name": "kriswallsmith/assetic",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kriswallsmith/assetic.git",
+                "reference": "735cffd3982c6e8cdebe292d5db39d077f65890f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/735cffd3982c6e8cdebe292d5db39d077f65890f",
+                "reference": "735cffd3982c6e8cdebe292d5db39d077f65890f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.1",
+                "symfony/process": "~2.1"
+            },
+            "require-dev": {
+                "cssmin/cssmin": "*",
+                "joliclic/javascript-packer": "*",
+                "kamicane/packager": "*",
+                "leafo/lessphp": "*",
+                "leafo/scssphp": "*",
+                "leafo/scssphp-compass": "*",
+                "mrclay/minify": "*",
+                "phpunit/phpunit": "~3.7",
+                "ptachoire/cssembed": "*",
+                "twig/twig": "~1.6"
+            },
+            "suggest": {
+                "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
+                "leafo/scssphp": "Assetic provides the integration with the scssphp SCSS compiler",
+                "leafo/scssphp-compass": "Assetic provides the integration with the SCSS compass plugin",
+                "ptachoire/cssembed": "Assetic provides the integration with phpcssembed to embed data uris",
+                "twig/twig": "Assetic provides the integration with the Twig templating engine"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Assetic": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kris Wallsmith",
+                    "email": "kris.wallsmith@gmail.com",
+                    "homepage": "http://kriswallsmith.net/"
+                }
+            ],
+            "description": "Asset Management for PHP",
+            "homepage": "https://github.com/kriswallsmith/assetic",
+            "keywords": [
+                "assets",
+                "compression",
+                "minification"
+            ],
+            "time": "2013-07-19 00:03:27"
+        },
+        {
+            "name": "robloach/component-installer",
+            "version": "0.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RobLoach/component-installer.git",
+                "reference": "1864f25db21fc173e02a359f646acd596c1b0460"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RobLoach/component-installer/zipball/1864f25db21fc173e02a359f646acd596c1b0460",
+                "reference": "1864f25db21fc173e02a359f646acd596c1b0460",
+                "shasum": ""
+            },
+            "require": {
+                "kriswallsmith/assetic": "1.*",
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "composer/composer": "1.*"
+            },
+            "type": "composer-installer",
+            "extra": {
+                "class": "ComponentInstaller\\Installer"
+            },
+            "autoload": {
+                "psr-0": {
+                    "ComponentInstaller": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Loach",
+                    "email": "robloach@gmail.com",
+                    "homepage": "http://robloach.net"
+                }
+            ],
+            "description": "Allows installation of Components via Composer.",
+            "time": "2013-08-31 23:46:48"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.4.1",
+            "target-dir": "Symfony/Component/Process",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/Process.git",
+                "reference": "58fdccb311e44f28866f976c2d7b3227e9f713db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/Process/zipball/58fdccb311e44f28866f976c2d7b3227e9f713db",
+                "reference": "58fdccb311e44f28866f976c2d7b3227e9f713db",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Symfony\\Component\\Process\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "http://symfony.com",
+            "time": "2014-01-05 02:10:50"
+        }
+    ],
+    "packages-dev": [
+
+    ],
+    "aliases": [
+
+    ],
+    "minimum-stability": "stable",
+    "stability-flags": [
+
+    ],
+    "platform": [
+
+    ],
+    "platform-dev": [
+
+    ]
+}


### PR DESCRIPTION
We're using this toolkit in a number of symfony projects.

It'd be really useful to be able include this library directly, rather than having to add this as an external package. Once this is merged in, there are two options, either the user can add this repository as a secondary repository in their composer.json, or you can register this repository on [packagist](https://packagist.org/), then the user won't need to add a new repository.

I've noticed for Node.JS/ROR you've chosen to keep the packages separate from this repository, so if you don't want to merge this in on those grounds, you could achieve a similar effect could be achieved by creating a composer.json file in a new repository that contained the following (warning: untested)

``` json
{
    "name": "alphagov/govuk_frontend_toolkit_composer",
    "type": "project",
    "description": "A collection of Sass and Javascript tools for generating frontend code.",
    "require": {
        "alphagov/govuk_frontend_toolkit": "dev-master"
    },
    "repositories": [
        {
            "type": "package",
            "package": {
                "name": "alphagov/govuk_frontend_toolkit",
                "version": "master",
                "type": "component",
                "source": {
                    "type": "git",
                    "reference": "master",
                    "url": "https://github.com/alphagov/govuk_frontend_toolkit.git"
                },
                "extra": {
                    "component": {
                        "scripts": [
                            "javascripts/**"
                        ],
                        "styles": [
                            "stylesheets/**"
                        ],
                        "files" : [
                            "images/**"
                        ]
                    }
                },
                "require": {
                    "robloach/component-installer": "*"
                }
            }
        }
    ]
}

```
