### PR TITLE
Look for external link images in their folder

### DIFF
--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -377,11 +377,11 @@ $is-print: false !default;
 
 @mixin external-link-default {
   &:after {
-    background-image: image-url("external-link.png");
+    background-image: image-url("external-links/external-link.png");
     background-repeat: no-repeat;
 
     @include device-pixel-ratio() {
-      background-image: image-url("external-link-24x24.png");
+      background-image: image-url("external-links/external-link-24x24.png");
       background-size: 12px 400px;
     }
   }
@@ -389,11 +389,11 @@ $is-print: false !default;
 
 @mixin external-link-heading {
   &:after {
-    background-image: image-url("external-link-black-12x12.png");
+    background-image: image-url("external-links/external-link-black-12x12.png");
     background-repeat: no-repeat;
 
     @include device-pixel-ratio() {
-      background-image: image-url("external-link-black-24x24.png");
+      background-image: image-url("external-links/external-link-black-24x24.png");
       background-size: 12px 400px;
     }
   }


### PR DESCRIPTION
Since they have been moved into a folder we should look in there. This
was causing [problems with the govuk_template build](https://github.com/alphagov/govuk_template/pull/52).
