### PR TITLE
Change visited link colour

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -92,7 +92,7 @@ $white: #fff;
 $link-colour: $govuk-blue;
 $link-active-colour: #2e8aca;
 $link-hover-colour: #2e8aca;
-$link-visited-colour: #2e8aca;
+$link-visited-colour: $govuk-blue;
 $button-colour: #00823b;
 $text-colour: $black;             // Standard text colour
 $secondary-text-colour: $grey-1;  // Section headers, help text etc.


### PR DESCRIPTION
Make it the same as default link colour for consistency and clearer, more legible lists of links.
@edds How does this make it into govuk_frontend_toolkit_gem? Can you assist?
