### PR TITLE
Add JavaScript to enable the use of PrimaryLists

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ var test = new GOVUK.MultivariateTest({
 });
 ```
 
-If you have a complex test, it may be worth extending MultivariateTest with 
+If you have a complex test, it may be worth extending MultivariateTest with
 your own. Callbacks can be strings which will call a method of that name
 on the current object.
 
@@ -668,6 +668,35 @@ Takes these options:
    - `callback`: Function to call when this cohort is chosen. If it is a string, that method on the test object is called.
 
 Full documentation on how to design multivariate tests, use the data in GA and construct hypothesis tests is on its way soon.
+
+## Primary Links
+
+`GOVUK.PrimaryList` hides elements in a list which don't have a supplied
+selector, they will then be shown when the user clicks. `GOVUK.primaryLinks` is
+a helper to add this behaviour to many elements.
+
+Example markup:
+
+```html
+<ul id="primary-list">
+  <li class="primary-item">Item 1</li>
+  <li>Item 2</li>
+  <li>Item 3</li>
+</ul>
+```
+
+To add it to all lists which have items with the class `primary-item` use
+something like:
+
+```javascript
+GOVUK.primaryLinks.init('.primary-item');
+```
+
+Or to add it just to that list you could use:
+
+```javascript
+new GOVUK.PrimaryList($('#primary-list'), '.primary-item');
+```
 
 
 ## Licence

--- a/javascripts/govuk/primary-links.js
+++ b/javascripts/govuk/primary-links.js
@@ -1,0 +1,49 @@
+(function() {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  // Only show the first {n} items in a list, documentation is in the README.md
+  var PrimaryList = function(el, selector){
+    this.$el = $(el);
+    this.$extraLinks = this.$el.find('li:not('+selector+')');
+    // only hide more than one extra link
+    if(this.$extraLinks.length > 1){
+      this.addToggleLink();
+      this.hideExtraLinks();
+    }
+  }
+  PrimaryList.prototype = {
+    toggleText: function(){
+      if(this.$extraLinks.length > 1){
+        return '+'+ this.$extraLinks.length +' others';
+      } else {
+        return '+'+ this.$extraLinks.length +' other';
+      }
+    },
+    addToggleLink: function(){
+      this.$toggleLink = $('<a href="#">'+ this.toggleText() + '</a>')
+      this.$toggleLink.click($.proxy(this.toggleLinks, this));
+      this.$toggleLink.insertAfter(this.$el);
+    },
+    toggleLinks: function(e){
+      e.preventDefault();
+      this.$toggleLink.remove();
+      this.showExtraLinks();
+    },
+    hideExtraLinks: function(){
+      this.$extraLinks.addClass('visuallyhidden');
+    },
+    showExtraLinks: function(){
+      this.$extraLinks.removeClass('visuallyhidden');
+    }
+  };
+  GOVUK.PrimaryList = PrimaryList;
+
+  GOVUK.primaryLinks = {
+    init: function(selector){
+      $(selector).parent().each(function(i, el){
+        new GOVUK.PrimaryList(el, selector);
+      });
+    }
+  }
+}());

--- a/spec/PrimaryLinksSpec.js
+++ b/spec/PrimaryLinksSpec.js
@@ -1,0 +1,49 @@
+describe('primary-links', function(){
+  var shortList, mediumList, longList;
+
+  beforeEach(function () {
+    shortList = $('<ul><li class="primary">one</li><li>two</li></ul>');
+    mediumList = $('<ul><li class="primary">one</li><li>two</li><li>three</li></ul>');
+    longList = $('<ul><li class="primary">one</li><li class="primary">two</li><li>three</li><li>four</li></ul>');
+  });
+
+  it('visually hides extra links', function(){
+    var list = new GOVUK.PrimaryList(mediumList, '.primary');
+    
+    expect(mediumList.find('.visuallyhidden').length).toBe(2);
+  });
+
+  it('creates appropriate toggle text', function(){
+    var short = new GOVUK.PrimaryList(shortList, '.primary');
+    var medium = new GOVUK.PrimaryList(mediumList, '.primary');
+    
+    expect(short.toggleText()).toEqual('+1 other');
+    expect(medium.toggleText()).toEqual('+2 others');
+  });
+
+  it('add a toggle link', function(){
+    var container = $('<div>').append(mediumList);
+    var list = new GOVUK.PrimaryList(mediumList, '.primary');
+
+    expect(container.find('a').length).toBe(1);
+  });
+
+  it('show extra links when toggled', function(){
+    var list = new GOVUK.PrimaryList(mediumList, '.primary');
+    var event = { preventDefault: function(){} };
+    spyOn(event, 'preventDefault');
+    spyOn(list, 'showExtraLinks');
+
+    list.toggleLinks(event);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(list.showExtraLinks).toHaveBeenCalled();
+  });
+
+  it('only adds toggle if more than one extra link', function(){
+    var short = new GOVUK.PrimaryList(shortList, '.primary');
+    var medium = new GOVUK.PrimaryList(mediumList, '.primary');
+    
+    expect(shortList.find('.visuallyhidden').length).toBe(0);
+    expect(mediumList.find('.visuallyhidden').length).toBe(2);
+  });
+});


### PR DESCRIPTION
One of the features implemented in [govspeak](https://github.com/alphagov/govspeak) is to allow long lists
to be collapsed to only show the first `n` items. This JavaScript makes
the frontend behaviour possible.

This JavaScript is already in [alphagov/specialist-frontend](https://github.com/alphagov/specialist-frontend) but is
needed in [alphagov/specialist-publisher](https://github.com/alphagov/specialist-publisher). Putting it here saves duplication.
