### PR TITLE
Add a file-path function for agnostic image urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ After setting the default, apply includes from the following for different font 
 
 `external-link-heading` is a unique style a background image for headings to groups of external links.
 
+This uses the `file-url` helper which will by default output an `image-url` to
+be used with Compass or Rails Asset Pipeline, if you want to use a static path
+then set the `$path` variable to point to the public location of the toolkit
+image assets.
+
 #### Description
 
 For a set style:

--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -1,6 +1,7 @@
 @import '_font_stack.scss';
 @import '_conditionals.scss';
 @import '_device-pixels.scss';
+@import '_url-helpers.scss';
 
 //  GOV.UK typography palettes
 
@@ -377,11 +378,11 @@ $is-print: false !default;
 
 @mixin external-link-default {
   &:after {
-    background-image: image-url("external-links/external-link.png");
+    background-image: file-url("external-links/external-link.png");
     background-repeat: no-repeat;
 
     @include device-pixel-ratio() {
-      background-image: image-url("external-links/external-link-24x24.png");
+      background-image: file-url("external-links/external-link-24x24.png");
       background-size: 12px 400px;
     }
   }
@@ -389,11 +390,11 @@ $is-print: false !default;
 
 @mixin external-link-heading {
   &:after {
-    background-image: image-url("external-links/external-link-black-12x12.png");
+    background-image: file-url("external-links/external-link-black-12x12.png");
     background-repeat: no-repeat;
 
     @include device-pixel-ratio() {
-      background-image: image-url("external-links/external-link-black-24x24.png");
+      background-image: file-url("external-links/external-link-black-24x24.png");
       background-size: 12px 400px;
     }
   }

--- a/stylesheets/_url-helpers.scss
+++ b/stylesheets/_url-helpers.scss
@@ -1,0 +1,16 @@
+// URL Helpers
+
+$path: false !default;
+
+// A function which can either output a image-url to be used with the Rails
+// Asset Pipeline or Compass or a plain url which is prefixed with a defined
+// path variable.
+@function file-url($file) {
+  $url: '';
+  @if $path {
+    $url: url($path+$file);
+  } @else {
+    $url: image-url($file);
+  }
+  @return $url;
+}


### PR DESCRIPTION
The `file-path` function will return either a url prefixed with the
contents of the `path` variable if it is set, or a `image-url` if it is
not set (the default). This lets you use the external link icons on
projects that only use vanilla Sass.

This fixes https://github.com/alphagov/govuk_frontend_toolkit/issues/95
