### PR TITLE
Improve contrast ratio of text colour for the phase banner

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -104,5 +104,6 @@ $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners
+$banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $mellow-red;       // Error text and border colour
 $error-background: #fef7f7;       // Error background colour

--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -26,16 +26,16 @@
   // No need to set a max-width for content inside .inner-block
   p {
     margin: 0;
-    color: $text-colour;
+    color: $banner-text-colour;
     @include core-16;
   }
 
   a, a:link, a:visited, a:active {
-    color: $text-colour;
+    color: $banner-text-colour;
   }
 
   a:hover {
-    color: $text-colour;
+    color: $banner-text-colour;
   }
 }
 


### PR DESCRIPTION
The $text-colour of black did not pass the contrast requirements for AA when displayed on either the Alpha or Beta banner colours.

$text-colour was also intended primarily for text on a white background, to make a version of black with a softer contrast. Orange and pink require a harder contrast so `#000000` is more appropriate.
