### PR TITLE
Improve CSS3 mixins

### DIFF
--- a/stylesheets/_css3.scss
+++ b/stylesheets/_css3.scss
@@ -32,6 +32,7 @@
 @mixin translate($x, $y) {
   -webkit-transform: translate($x, $y); // Still in use now, started at: Chrome 4.0, Safari 3.1, Mobile Safari 3.2, Android 2.1
      -moz-transform: translate($x, $y); // Firefox 3.5 to 15.0
+      -ms-transform: translate($x, $y); // IE9 only
        -o-transform: translate($x, $y); // Opera 10.5 to 12.0
           transform: translate($x, $y);
 }


### PR DESCRIPTION
- Add `transform: scale(x, y);` mixin with vendor prefixes
- Comments. Lots of them. Maybe too many? I would be interested in your opinions.
- Add unprefixed `background-image: linear-gradient();`
- Add `-ms-transform: translate(x, y);`
