### PR TITLE
Set inner block to use padding or margin

### DIFF
--- a/stylesheets/_grid_layout.scss
+++ b/stylesheets/_grid_layout.scss
@@ -19,18 +19,25 @@
 //    @include outer-block;
 // }
 
-// Inner block sets gutters to align content with header and footer
-@mixin inner-block {
-  padding-left: $gutter-half;
-  padding-right: $gutter-half;
+// Inner block sets either margin or padding
+// to align content with header and footer
+@mixin inner-block($margin-or-padding: padding) {
+  #{$margin-or-padding}-left: $gutter-half;
+  #{$margin-or-padding}-right: $gutter-half;
   @include media(tablet) {
-    padding-left: $gutter;
-    padding-right: $gutter;
+    #{$margin-or-padding}-left: $gutter;
+    #{$margin-or-padding}-right: $gutter;
   }
 }
 
 // Inner block usage:
 //
+// By default, inner block sets padding
 // .inner-block {
 //    @include inner-block;
+// }
+//
+// To set margins instead of padding:
+// .inner-block {
+//    @include inner-block(margin);
 // }


### PR DESCRIPTION
If `.inner-block` has a top or bottom border, margins must be used rather than padding - or the border is too wide.

Here, left and right padding is set as the default.
The same mixin can now be used to set left and right margins.
