### PR TITLE
Increase button padding

### DIFF
--- a/stylesheets/design-patterns/_buttons.scss
+++ b/stylesheets/design-patterns/_buttons.scss
@@ -27,7 +27,7 @@
   // Size and shape
   position: relative;
   @include inline-block;
-  padding: 10px $gutter-half 5px $gutter-half;
+  padding: 0.3em 0.6em 0.2em 0.6em;
   border: none;
   @include border-radius(0);
   -webkit-appearance: none;


### PR DESCRIPTION
- Match padding in GOV.UK elements guide
- Button padding then won’t have to be overridden here:
  https://github.com/alphagov/govuk_elements/blob/master/public/sass/eleme
  nts/_buttons.scss
