### PR TITLE
Abstract the core typography mixins into single core mixin

### DIFF
--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -39,35 +39,59 @@ $is-print: false !default;
 
 
 @mixin core-80($line-height: (80 / 80), $line-height-640: (55 / 53), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 80px, $font-size-640: 53px, $font-size-print: 28pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 80px;
+  $font-size-640: 53px;
+  $font-size-print: 28pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-48($line-height: (50 / 48), $line-height-640: (35 / 32), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 48px, $font-size-640: 32px, $font-size-print: 18pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 48px;
+  $font-size-640: 32px;
+  $font-size-print: 18pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-36($line-height: (40 / 36), $line-height-640: (25 / 24), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 36px, $font-size-640: 24px, $font-size-print: 18pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 36px;
+  $font-size-640: 24px;
+  $font-size-print: 18pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-27($line-height: (30 / 27), $line-height-640: (20 / 18), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 27px, $font-size-640: 20px, $font-size-print: 16pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 27px;
+  $font-size-640: 20px;
+  $font-size-print: 16pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-24($line-height: (30 / 24), $line-height-640: (24 / 20), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 24px, $font-size-640: 18px, $font-size-print: 16pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 24px;
+  $font-size-640: 18px;
+  $font-size-print: 16pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-19($line-height: (25 / 19), $line-height-640: (20 / 16), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 19px, $font-size-640: 16px, $font-size-print: 14pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 19px;
+  $font-size-640: 16px;
+  $font-size-print: 14pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-16($line-height: (20 / 16), $line-height-640: (16 / 14), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 16px, $font-size-640: 14px, $font-size-print: 12pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 16px;
+  $font-size-640: 14px;
+  $font-size-print: 12pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin core-14($line-height: (20 / 14), $line-height-640: (15 / 12), $tabular-numbers: false, $font-weight: 400) {
-  @include _core-font-generator($font-size: 14px, $font-size-640: 12px, $font-size-print: 11pt, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+  $font-size: 14px;
+  $font-size-640: 12px;
+  $font-size-print: 11pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
 @mixin bold-80($line-height: (80 / 80), $line-height-640: (55 / 53), $tabular-numbers: false) {


### PR DESCRIPTION
Making the codebase more DRY (don't repeat yourself).
Create a single core() mixin which accepts $font-size, $font-size-640 and $font-size-print in addition to the existing $line-height, $line-height-640 and $tabular-numbers.
Existing mixins call the new core base.
If you pass no arguments, you get core-19.
Dubious merit of allowing creation of new core font sizes.
