### PR TITLE
Add polyfill for Function.prototype.bind

### DIFF
--- a/javascripts/vendor/polyfills/bind.js
+++ b/javascripts/vendor/polyfills/bind.js
@@ -1,0 +1,40 @@
+// Function.prototype.bind
+//
+// A polyfill for Function.prototype.bind. Which lets you bind a defined
+// value to the `this` keyword in a function call.
+//
+// Bind is natively supported in:
+//   IE9+
+//   Chrome 7+
+//   Firefox 4+
+//   Safari 5.1.4+
+//   iOS 6+
+//   Android Browser 4+
+//   Chrome for Android 0.16+
+//
+// Originally from:
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+if (!Function.prototype.bind) {
+  Function.prototype.bind = function (oThis) {
+    if (typeof this !== "function") {
+      // closest thing possible to the ECMAScript 5
+      // internal IsCallable function
+      throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
+    }
+
+    var aArgs = Array.prototype.slice.call(arguments, 1),
+        fToBind = this,
+        fNOP = function () {},
+        fBound = function () {
+          return fToBind.apply(this instanceof fNOP && oThis
+                 ? this
+                 : oThis,
+                 aArgs.concat(Array.prototype.slice.call(arguments)));
+        };
+
+    fNOP.prototype = this.prototype;
+    fBound.prototype = new fNOP();
+
+    return fBound;
+  };
+}


### PR DESCRIPTION
So that we can easily bind a `this` to function calls in event handlers.

---

We are currently writing lots of JavaScript using a style like:

``` javascript
$el.click($.proxy(this.clickHandler, this));
```

I am proposing we switch to using the new `Function.prototype.bind` syntax so that same call would look like:

``` javascript
$el.click(this.clickHandler.bind(this));
```

Bind is supported natively in modern browsers and is the way that binding a `this` will be done in the future. It is also slightly cleaner syntax. 

The reasons not to do this is extending native prototypes is often seen as bad practice in JavaScript. It will effect what happens when you try and do a `for(attribute in object)` as the methods we have added to the prototype will also be listed. However, the number of times you will try and do a loop like that on a function is very small and in that case we should be either adding a check for `hasOwnProperty` or using a jQuery iterator.

Having the polyfill in the toolkit means we wouldn't need to add it to each project individually.
