### PR TITLE
Add basic Sass test to check our Sass compiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+rvm:
+  - 2.1.0
+before_install:
+  - gem install sass

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,26 @@
 module.exports = function(grunt) {
+  var allSassFiles = [];
+
+  var path = require('path');
+
+  grunt.file.recurse(
+    "./stylesheets/",
+    function(abspath, rootdir, subdir, filename) {
+      if (filename.match(/\.scss/)) {
+        allSassFiles.push("@import '" + abspath + "';");
+      }
+    }
+  );
+
+  grunt.file.write(
+    "./spec/stylesheets/test.scss",
+    allSassFiles.join("\n")
+  );
+
   grunt.initConfig({
+    clean: {
+      sass: ["spec/stylesheets/test*css"]
+    },
     jasmine: {
       javascripts: {
         src: [
@@ -11,9 +32,24 @@ module.exports = function(grunt) {
           helpers: 'spec/unit/*Helper.js'
         }
       }
+    },
+    sass: {
+      development: {
+        files: {
+          './spec/stylesheets/test-out.css': './spec/stylesheets/test.scss'
+        },
+        options: {
+          loadPath: [
+            './stylesheets'
+          ],
+          style: 'nested',
+        }
+      },
     }
   });
+  grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
-  grunt.registerTask('test', ['jasmine']);
+  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.registerTask('test', ['sass', 'clean', 'jasmine']);
   grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "0.1.11",
+    "grunt-contrib-clean":"~0.6.0",
     "grunt-contrib-jasmine": "~0.5.2",
+    "grunt-contrib-sass": "0.7.4",
     "jquery-browser": "~1.7.2-3"
   },
   "scripts": {


### PR DESCRIPTION
Tested by reverting 31b973d11c968a5db5a4e4de5a19508eac932333 and running
the tests. They failed with:

```
> grunt 
Running "sass:development" (sass) task
Syntax error: Positional arguments must come before keyword arguments.
        on line 42 of /Users/jabley/govuk/govuk_frontend_toolkit/stylesheets/_typography.scss
        from line 2 of /Users/jabley/govuk/govuk_frontend_toolkit/stylesheets/design-patterns/_alpha-beta.scss
        from line 6 of spec/stylesheets/test.scss
  Use --trace for backtrace.
Warning: Exited with error code 1 Use --force to continue.

Aborted due to warnings.
```
