### PR TITLE
Add a note on the selection buttons options

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,13 @@ var $buttons = $("label input[type='radio'], label input[type='checkbox']");
 GOVUK.selectionButtons($buttons);
 ```
 
+The classes that get added can be passed in as options:
+
+```
+var $buttons = $("label input[type='radio'], label input[type='checkbox']");
+GOVUK.selectionButtons($buttons, { focusedClass : 'selectable-focused', selectedClass : 'selectable-selected' });
+```
+
 Note that `GOVUK.selectionButtons` and the constructors it wraps, `GOVUK.RadioButtons` and `GOVUK.CheckboxButtons` use the `bind.js` polyfill.
 
 ## Licence


### PR DESCRIPTION
The options you can send into the `GOVUK.selectionButtons` function were not mentioned in the **Selection buttons** documentation when it was first added in [#21](https://github.com/alphagov/govuk_frontend_toolkit/pull/121).
