### PR TITLE
Remove $ignore-for-ie: true to set auto margins

### DIFF
--- a/stylesheets/_grid_layout.scss
+++ b/stylesheets/_grid_layout.scss
@@ -24,7 +24,7 @@ $site-width: 960px;
   @include media(tablet){
     margin: 0 $gutter;
   }
-  @include media($min-width: ($site-width + $gutter * 2), $ignore-for-ie: true){
+  @include media($min-width: ($site-width + $gutter * 2)){
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
IE stylesheets then render the following where %site-width-container is
used:

margin: 0 15px;
margin: 0 30px;
margin: 0 auto;

So the auto margin overrides the left and right margins.
