### PR TITLE
Fix outdent to full width placeholder

### DIFF
--- a/stylesheets/_grid_layout.scss
+++ b/stylesheets/_grid_layout.scss
@@ -41,7 +41,7 @@ $site-width: 960px;
 // }
 %outdent-to-full-width {
   margin-left: -$gutter-half;
-  margin-left: -$gutter-half;
+  margin-right: -$gutter-half;
   @include media(tablet){
     margin-left: -$gutter;
     margin-right: -$gutter;


### PR DESCRIPTION
This should be margin right, not margin left for smaller screens.
Spotted by @alexmuller
