### PR TITLE
Add an option to the grid mixins to float right

### DIFF
--- a/stylesheets/_grid_layout.scss
+++ b/stylesheets/_grid_layout.scss
@@ -85,9 +85,9 @@ $site-width: 960px;
 //     @include grid-column( 1/3, $full-width: desktop );
 //   }
 
-@mixin grid-column($width, $full-width: tablet) {
+@mixin grid-column($width, $full-width: tablet, $float: left) {
   @include media($full-width){
-    float: left;
+    float: $float;
     width: percentage($width);
   }
   @include ie-lte(7){


### PR DESCRIPTION
In some situations, like when you are displaying right to left arabic content,
you will want the columns to be floated the other way. This adds an optional
option to let you specify the float so you can achieve that.
