### PR TITLE
Update licence to correct format and date

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright (c) 2014 HM Government
+Copyright (c) 2015 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Crown Copyright (Government Digital Service)
+Copyright (c) 2012 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
As per instructions from @annashipman, the copyright for this project should read "Crown Copyright", not "HM Government".