### PR TITLE
Don’t print phase banners

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -36,6 +36,10 @@
       vertical-align: baseline;
     }
   }
+
+  @if $is-print == true {
+    display: none;
+  }
 }
 
 // Phase tag usage:


### PR DESCRIPTION
The phase banner (alpha/beta banner) should not be printed as it is not relevant to the printed page.