### PR TITLE
Analytics - error tracking and print intent - don't run on load

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -45,6 +45,10 @@ The minimum you need to use the analytics function is:
   // Set custom dimensions before tracking pageviews
   // GOVUK.analytics.setDimension(…)
 
+  // Activate any event plugins eg. print intent, error tracking
+  // GOVUK.analyticsPlugins.error();
+  // GOVUK.analyticsPlugins.printIntent();
+
   // Track initial pageview
   GOVUK.analytics.trackPageview();
 })();
@@ -151,8 +155,8 @@ function setPixelDensityDimension(pixelDensity) {
 
 ## Print tracking
 
-Pull `print-intent.js` into your project, after analytics has been initialised, to track when users are attempting to print content.
+Pull `print-intent.js` into your project, and initialise it after analytics (see [Create an analytics tracker, above](#create-an-analytics-tracker)), to track when users are attempting to print content.
 
 ## Error tracking
 
-Pull `error-tracking.js` into your project, after analytics has been initialised, to track JavaScript errors.
+Pull `error-tracking.js` into your project, and initialise it after analytics (see [Create an analytics tracker, above](#create-an-analytics-tracker)), to track JavaScript errors.

--- a/javascripts/govuk/analytics/error-tracking.js
+++ b/javascripts/govuk/analytics/error-tracking.js
@@ -2,21 +2,26 @@
 (function() {
 
   "use strict";
-  var trackJavaScriptError = function (e) {
-    var errorSource = e.filename + ': ' + e.lineno;
-    GOVUK.analytics.trackEvent('JavaScript Error', e.message, {
-      label: errorSource,
-      value: 1,
-      nonInteraction: true
-    });
-  };
 
-  if (window.addEventListener) {
-    window.addEventListener('error', trackJavaScriptError, false);
-  } else if (window.attachEvent) {
-    window.attachEvent('onerror', trackJavaScriptError);
-  } else {
-    window.onerror = trackJavaScriptError;
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
+
+  GOVUK.analyticsPlugins.error = function () {
+    var trackJavaScriptError = function (e) {
+      var errorSource = e.filename + ': ' + e.lineno;
+      GOVUK.analytics.trackEvent('JavaScript Error', e.message, {
+        label: errorSource,
+        value: 1,
+        nonInteraction: true
+      });
+    };
+
+    if (window.addEventListener) {
+      window.addEventListener('error', trackJavaScriptError, false);
+    } else if (window.attachEvent) {
+      window.attachEvent('onerror', trackJavaScriptError);
+    } else {
+      window.onerror = trackJavaScriptError;
+    }
   }
 
 }());

--- a/javascripts/govuk/analytics/print-intent.js
+++ b/javascripts/govuk/analytics/print-intent.js
@@ -1,31 +1,36 @@
 // Extension to monitor attempts to print pages.
 (function () {
-
   "use strict";
-  var printAttempt = (function () {
-    GOVUK.analytics.trackEvent('Print Intent', document.location.pathname);
-  });
 
-  // Most browsers
-  if (window.matchMedia) {
-    var mediaQueryList = window.matchMedia('print'),
-      mqlListenerCount = 0;
-    mediaQueryList.addListener(function (mql) {
-      if (!mql.matches && mqlListenerCount === 0) {
-        printAttempt();
-        mqlListenerCount++;
-        // If we try and print again in 3 seconds, don't log it
-        window.setTimeout(function () {
-          mqlListenerCount = 0;
-          // printing will be tracked again now
-        }, 1e3);
-      }
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
+
+  GOVUK.analyticsPlugins.printIntent = function () {
+    var printAttempt = (function () {
+      GOVUK.analytics.trackEvent('Print Intent', document.location.pathname);
     });
-  }
 
-  // IE < 10
-  if (window.onafterprint) {
-    window.onafterprint = printAttempt;
-  }
+    // Most browsers
+    if (window.matchMedia) {
+      var mediaQueryList = window.matchMedia('print'),
+        mqlListenerCount = 0;
+      mediaQueryList.addListener(function (mql) {
+        if (!mql.matches && mqlListenerCount === 0) {
+          printAttempt();
+          mqlListenerCount++;
+          // If we try and print again in 3 seconds, don't log it
+          window.setTimeout(function () {
+            mqlListenerCount = 0;
+            // printing will be tracked again now
+          }, 1e3);
+        }
+      });
+    }
+
+    // IE < 10
+    if (window.onafterprint) {
+      window.onafterprint = printAttempt;
+    }
+
+  };
 
 }());


### PR DESCRIPTION
As the JS for these two analytics plugins will often be bundled by default, they shouldn't run automatically. This is because they might not have been loaded after the main Tracker file.
So instead, they should be run explicitly from the code in the analytics 'init' file, after the Tracker has been set up. See [the docs](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md) for details and example.