### PR TITLE
Move classic analytics logic into classic tracker

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-classic-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-classic-tracker.js
@@ -104,8 +104,24 @@
 
   // https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables
   GoogleAnalyticsClassicTracker.prototype.setCustomVariable = function(index, value, name, scope) {
+    var PAGE_LEVEL_SCOPE = 3;
+    scope = scope || PAGE_LEVEL_SCOPE;
+
+    if (typeof index !== "number") {
+      index = parseInt(index, 10);
+    }
+
+    if (typeof scope !== "number") {
+      scope = parseInt(scope, 10);
+    }
+
     _gaq.push(['_setCustomVar', index, name, String(value), scope]);
   };
+
+  // Match tracker and universal API
+  GoogleAnalyticsClassicTracker.prototype.setDimension = function(index, value, name, scope) {
+    this.setCustomVariable(index, value, name, scope);
+  }
 
   GOVUK.GoogleAnalyticsClassicTracker = GoogleAnalyticsClassicTracker;
 })();

--- a/javascripts/govuk/analytics/tracker.js
+++ b/javascripts/govuk/analytics/tracker.js
@@ -42,17 +42,6 @@
     Check this for your app before using this
    */
   Tracker.prototype.setDimension = function(index, value, name, scope) {
-    var PAGE_LEVEL_SCOPE = 3;
-    scope = scope || PAGE_LEVEL_SCOPE;
-
-    if (typeof index !== "number") {
-      index = parseInt(index, 10);
-    }
-
-    if (typeof scope !== "number") {
-      scope = parseInt(scope, 10);
-    }
-
     this.universal.setDimension(index, value);
     this.classic.setCustomVariable(index, value, name, scope);
   };


### PR DESCRIPTION
* Scope only applies to classic analytics, that’s where the default should be applied
* Index and Scope only need to be numbers in classic (in Universal index becomes “dimension1”)
* Add a `setDimension` call to classic for API parity (easier switching from classic to universal without simultaneous tracking)