### PR TITLE
Track a print pageview on print attempt

### DIFF
--- a/javascripts/govuk/analytics/print-intent.js
+++ b/javascripts/govuk/analytics/print-intent.js
@@ -7,6 +7,7 @@
   GOVUK.analyticsPlugins.printIntent = function () {
     var printAttempt = (function () {
       GOVUK.analytics.trackEvent('Print Intent', document.location.pathname);
+      GOVUK.analytics.trackPageview('/print' + document.location.pathname);
     });
 
     // Most browsers
@@ -21,7 +22,7 @@
           window.setTimeout(function () {
             mqlListenerCount = 0;
             // printing will be tracked again now
-          }, 1e3);
+          }, 1000);
         }
       });
     }

--- a/javascripts/govuk/analytics/print-intent.js
+++ b/javascripts/govuk/analytics/print-intent.js
@@ -18,11 +18,11 @@
         if (!mql.matches && mqlListenerCount === 0) {
           printAttempt();
           mqlListenerCount++;
-          // If we try and print again in 3 seconds, don't log it
+          // If we try and print again within 3 seconds, don't log it
           window.setTimeout(function () {
             mqlListenerCount = 0;
             // printing will be tracked again now
-          }, 1000);
+          }, 3000);
         }
       });
     }


### PR DESCRIPTION
Match the old static behaviour and technique of prefixing `/print` in front of the current path then tracking a pageview.

PR corresponds with the following change to static:
https://github.com/alphagov/static/compare/delete-print-tracking

Story: https://www.pivotaltracker.com/story/show/88896084

cc @benilovj @wryobservations 