### PR TITLE
Update error colour fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .sass-cache
-
+npm-debug.log
 /spec/stylesheets/test-out.css.map

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -71,18 +71,16 @@
   };
 
   MultivariateTest.prototype.setCustomVar = function(cohort) {
-    window._gaq = window._gaq || [];
-    window._gaq.push([
-      '_setCustomVar',
-      this.customVarIndex,
-      this.cookieName(),
-      cohort,
+    GOVUK.analytics.setDimension(
+      this.customVarIndex, 
+      this.cookieName(), 
+      cohort, 
       2 // session level
-    ]);
+    ); 
     // Fire off a dummy event to set the custom var on the page.
     // Ideally we'd be able to call setCustomVar before trackPageview,
     // but would need reordering the existing GA code.
-    window._gaq.push(['_trackEvent', this.cookieName(), 'run', '-', 0, true]);
+    GOVUK.analytics.trackEvent(this.cookieName(), 'run', {nonInteraction:true});
   };
 
   MultivariateTest.prototype.weightedCohortNames = function() {

--- a/spec/unit/MultivariateTestSpec.js
+++ b/spec/unit/MultivariateTestSpec.js
@@ -1,7 +1,9 @@
 describe("MultivariateTest", function() {
   beforeEach(function() {
     GOVUK.cookie = jasmine.createSpy('GOVUK.cookie');
-    window._gaq = [];
+    GOVUK.analytics = {setDimension:function(){}, trackEvent:function(){}};
+    spyOn(GOVUK.analytics, "setDimension");
+    spyOn(GOVUK.analytics, "trackEvent");
   });
 
   describe("#run", function() {
@@ -53,23 +55,17 @@ describe("MultivariateTest", function() {
         },
         customVarIndex: 2
       });
-      expect(window._gaq).toEqual([
-        [
-          '_setCustomVar',
-          2,
-          'multivariatetest_cohort_stuff',
-          'foo',
-          2
-        ],
-        [
-          '_trackEvent',
-          'multivariatetest_cohort_stuff',
-          'run',
-          '-',
-          0,
-          true
-        ]
-      ]);
+      expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(
+        2,
+        'multivariatetest_cohort_stuff',
+        'foo',
+        2
+      );
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'multivariatetest_cohort_stuff',
+        'run',
+        {nonInteraction:true}
+      );
     });
 
     it("should set html for a cohort", function() {

--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -105,5 +105,5 @@ $page-colour: $white;             // The page
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: $mellow-red;       // Error text and border colour
+$error-colour: #af1324;           // Error text and border colour
 $error-background: #fef7f7;       // Error background colour


### PR DESCRIPTION
Change $error-colour from $mellow-red: #df3034 to the darker #af1324.

On a white background, #af1324 has a contrast ratio of 7:14:1 and
meets level AAA, this should provide enough contrast between text and
its background so that it can be read by people with moderately low
vision.

http://www.w3.org/WAI/WCAG20/quickref/#qr-visual-audio-contrast7

This will be used for error text and also for the border to the left of
an error, or the border of an error summary box.