### PR TITLE
Change error colour to a darker red

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -105,5 +105,5 @@ $page-colour: $white;             // The page
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: $mellow-red;       // Error text and border colour
+$error-colour: #af1324;           // Error text and border colour
 $error-background: #fef7f7;       // Error background colour


### PR DESCRIPTION
Change $error-colour from $mellow-red: #df3034 to the darker #af1324.

On a white background, #af1324 has a contrast ratio of 7:14:1 and
meets level AAA, this should provide enough contrast between text and
its background so that it can be read by people with moderately low
vision.

http://www.w3.org/WAI/WCAG20/quickref/#qr-visual-audio-contrast7

This will be used for error text and also for the border to the left of
an error, or the border of an error summary box.