### PR TITLE
multivariate-test.js: bugfix for content experiment settings

### DIFF
--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -87,7 +87,9 @@
   MultivariateTest.prototype.setUpContentExperiment = function(cohort) {
     var contentExperimentId = this.contentExperimentId;
     var cohortVariantId = this.cohorts[cohort]['variantId'];
-    if(contentExperimentId && cohortVariantId && typeof window.ga === "function"){
+    if(typeof contentExperimentId !== 'undefined' &&
+      typeof cohortVariantId !== 'undefined' &&
+      typeof window.ga === "function"){
       window.ga('set', 'expId', contentExperimentId);
       window.ga('set', 'expVar', cohortVariantId);
     };

--- a/spec/unit/MultivariateTestSpec.js
+++ b/spec/unit/MultivariateTestSpec.js
@@ -187,10 +187,10 @@ describe("MultivariateTest", function() {
       var test = new GOVUK.MultivariateTest({
         name: 'stuff',
         contentExperimentId: "asdfsadasdfa",
-        cohorts: {foo: {variantId: 0, weight: 0},  bar: {variantId: 1, weight: 1}}
+        cohorts: {foo: {variantId: 0, weight: 1},  bar: {variantId: 1, weight: 0}}
       });
       expect(window.ga.calls.first().args).toEqual(['set', 'expId', 'asdfsadasdfa']);
-      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'expVar', 1]);
+      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'expVar', 0]);
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'multivariatetest_cohort_stuff',
         'run',


### PR DESCRIPTION
Before this fix, when a user fell into variant 0 of a multivariate test,
the data wouldn't be reported to Google correctly because of a broken
null check in the code block that opts the user into the Google Content
Experiment.

/cc @fofr 