### PR TITLE
Add cross domain tracking to Tracker object

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -160,3 +160,15 @@ Pull `print-intent.js` into your project, and initialise it after analytics (see
 ## Error tracking
 
 Pull `error-tracking.js` into your project, and initialise it after analytics (see [Create an analytics tracker, above](#create-an-analytics-tracker)), to track JavaScript errors.
+
+## Tracking across domains
+
+Once a Tracker instance has been created, tracking across domains can be set up
+for pages like:
+
+```js
+GOVUK.analytics.addLinkedTrackerDomain(trackerIdHere, nameForTracker, domainToLinkTo);
+```
+
+Once this is done hits to that page will be tracked in both your local and the
+named tracker, and sessions will persist to the other domain.

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -89,6 +89,29 @@
     });
   };
 
+  /*
+   https://developers.google.com/analytics/devguides/collection/analyticsjs/cross-domain
+   trackerId - the UA account code to track the domain against
+   name      - name for the tracker
+   domain    - the domain to track
+  */
+  GoogleAnalyticsUniversalTracker.prototype.addLinkedTrackerDomain = function(trackerId, name, domain) {
+    sendToGa('create',
+             trackerId,
+             'auto',
+             {'name': name});
+    // Load the plugin.
+    sendToGa('require', 'linker');
+    sendToGa(name + '.require', 'linker');
+
+    // Define which domains to autoLink.
+    sendToGa('linker:autoLink', [domain]);
+    sendToGa(name + '.linker:autoLink', [domain]);
+
+    sendToGa(name + '.set', 'anonymizeIp', true);
+    sendToGa(name + '.send', 'pageview');
+  };
+
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
   GoogleAnalyticsUniversalTracker.prototype.setDimension = function(index, value) {
     sendToGa('set', 'dimension' + index, String(value));

--- a/javascripts/govuk/analytics/tracker.js
+++ b/javascripts/govuk/analytics/tracker.js
@@ -46,5 +46,12 @@
     this.classic.setCustomVariable(index, value, name, scope);
   };
 
+  /*
+   Add a beacon to track a page in another GA account on another domain.
+   */
+  Tracker.prototype.addLinkedTrackerDomain = function(trackerId, name, domain) {
+    this.universal.addLinkedTrackerDomain(trackerId, name, domain);
+  };
+
   GOVUK.Tracker = Tracker;
 })();

--- a/spec/unit/analytics/TrackerSpec.js
+++ b/spec/unit/analytics/TrackerSpec.js
@@ -71,4 +71,25 @@ describe("GOVUK.Tracker", function() {
     });
   });
 
+  describe('when adding a linked domain', function() {
+    beforeEach(function() {
+      tracker = new GOVUK.Tracker(this.config);
+    });
+
+    it('adds a linked domain to universal only', function() {
+      window._gaq = [];
+      tracker.addLinkedTrackerDomain('1234', 'test', 'www.example.com');
+
+      expect(window._gaq).toEqual([]);
+      var allArgs = window.ga.calls.allArgs()
+      expect(allArgs).toContain(['create', '1234', 'auto', {'name': 'test'}]);
+      expect(allArgs).toContain(['require', 'linker']);
+      expect(allArgs).toContain(['test.require', 'linker']);
+      expect(allArgs).toContain(['linker:autoLink', ['www.example.com']]);
+      expect(allArgs).toContain(['test.linker:autoLink', ['www.example.com']]);
+      expect(allArgs).toContain(['test.set', 'anonymizeIp', true]);
+      expect(allArgs).toContain(['test.send', 'pageview']);
+    });
+  });
+
 });


### PR DESCRIPTION
So that pages that link to known partners can allow those partners to track full user journeys, this commit adds the necessary GA and UA incantations to link domains and separate accounts together.

This is to enable the removal of bespoke HTML code in several transaction start pages across GOV.UK.

One thing I'm not sure about - do we need to support separate UA and GA account IDs? @fofr @benilovj 