### PR TITLE
Make tests run in browser

### DIFF
--- a/spec/manifest.js
+++ b/spec/manifest.js
@@ -6,12 +6,19 @@ var manifest = {
     '../../javascripts/govuk/primary-links.js',
     '../../javascripts/govuk/stick-at-top-when-scrolling.js',
     '../../javascripts/govuk/stop-scrolling-at-footer.js',
-    '../../javascripts/govuk/selection-buttons.js'
+    '../../javascripts/govuk/selection-buttons.js',
+    '../../javascripts/govuk/analytics/google-analytics-classic-tracker.js',
+    '../../javascripts/govuk/analytics/google-analytics-universal-tracker.js',
+    '../../javascripts/govuk/analytics/tracker.js'
+
   ],
   test : [
     '../unit/MultivariateTestSpec.js',
     '../unit/PrimaryLinksSpec.js',
     '../unit/StickAtTopWhenScrollingSpec.js',
-    '../unit/SelectionButtonSpec.js'
+    '../unit/SelectionButtonSpec.js',
+    '../unit/analytics/GoogleAnalyticsClassicTrackerSpec.js',
+    '../unit/analytics/GoogleAnalyticsUniversalTrackerSpec.js',
+    '../unit/analytics/TrackerSpec.js'
   ]
 };

--- a/spec/support/LocalTestRunner.html
+++ b/spec/support/LocalTestRunner.html
@@ -3,16 +3,16 @@
 <head>
   <title>Jasmine Test Runner</title>
 
-  <link rel="stylesheet" type="text/css" href="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-1.3.1/jasmine.css">
+  <link rel="stylesheet" type="text/css" href="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.1/jasmine.css">
   <style>
     #wrapper { display: none; }
   </style>
 
   <!-- JASMINE FILES -->
-  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-1.3.1/jasmine.js"></script>
-  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-1.3.1/jasmine-html.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.1/jasmine.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.1/jasmine-html.js"></script>
 
-  <script type="text/javascript" src="./console-runner.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/vendor/jasmine-2.0.1/boot.js"></script>
   <script type="text/javascript" src="./load.js"></script>
 </head>
 <body>

--- a/spec/support/load.js
+++ b/spec/support/load.js
@@ -1,5 +1,5 @@
 (function (root) {
-  "use strict";
+  "use strict"
   var loadedScripts = 0,
       totalScripts,
       merge,
@@ -22,7 +22,7 @@
   };
   loadScript = function (src, nextIdx) {
     var script = document.createElement('script'),
-        nextScript; 
+        nextScript;
 
     script.type = 'text/javascript';
     script.src = src;
@@ -32,23 +32,15 @@
     script.onload = function () {
       if (nextIdx < totalScripts.length) {
         loadScript(totalScripts[nextIdx], nextIdx + 1);
-      } else {
-        runJasmine();
       }
     };
     return script;
-  };
-  runJasmine = function () {
-    var console_reporter = new jasmine.ConsoleReporter();
-    jasmine.getEnv().addReporter(new jasmine.TrivialReporter());
-    jasmine.getEnv().addReporter(console_reporter);
-    jasmine.getEnv().execute();
   };
   manifestScript = loadScript('../manifest.js');
 
   manifestScript.onload = function () {
     var idx = 0;
-  
+
     totalScripts = merge([manifest.support, manifest.test]);
     loadScript(totalScripts[idx], idx + 1);
   };


### PR DESCRIPTION
The upgrade to `grunt-contrib-jasmine 0.8.2` in https://github.com/alphagov/govuk_frontend_toolkit/commit/5fa6d6d522fa9a4996c3ffd50c4d6808f6b0615a updated Jasmine to 2.0.0 which broke the local test runner.

This PR fixes the test runner to work with Jasmine 2.0.0