### PR TITLE
Make tracker.js more liberal in what it accepts

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-classic-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-classic-tracker.js
@@ -121,7 +121,10 @@
   // Match tracker and universal API
   GoogleAnalyticsClassicTracker.prototype.setDimension = function(index, value, name, scope) {
     this.setCustomVariable(index, value, name, scope);
-  }
+  };
+
+  // Match tracker and universal API
+  GoogleAnalyticsClassicTracker.prototype.addLinkedTrackerDomain = function() {};
 
   GOVUK.GoogleAnalyticsClassicTracker = GoogleAnalyticsClassicTracker;
 })();

--- a/javascripts/govuk/analytics/tracker.js
+++ b/javascripts/govuk/analytics/tracker.js
@@ -16,7 +16,7 @@
   };
 
   Tracker.prototype.trackPageview = function(path, title) {
-    this.classic.trackPageview(path);
+    this.classic.trackPageview(path, title);
     this.universal.trackPageview(path, title);
   };
 
@@ -42,8 +42,8 @@
     Check this for your app before using this
    */
   Tracker.prototype.setDimension = function(index, value, name, scope) {
-    this.universal.setDimension(index, value);
-    this.classic.setCustomVariable(index, value, name, scope);
+    this.universal.setDimension(index, value, name, scope);
+    this.classic.setDimension(index, value, name, scope);
   };
 
   /*

--- a/javascripts/govuk/analytics/tracker.js
+++ b/javascripts/govuk/analytics/tracker.js
@@ -6,8 +6,13 @@
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
   var Tracker = function(config) {
-    this.universal = new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain);
-    this.classic = new GOVUK.GoogleAnalyticsClassicTracker(config.classicId, config.cookieDomain);
+    this.trackers = [];
+    if (typeof config.universalId != 'undefined') {
+      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain));
+    }
+    if (typeof config.classicId != 'undefined') {
+      this.trackers.push(new GOVUK.GoogleAnalyticsClassicTracker(config.classicId, config.cookieDomain));
+    }
   };
 
   Tracker.load = function() {
@@ -16,8 +21,9 @@
   };
 
   Tracker.prototype.trackPageview = function(path, title) {
-    this.classic.trackPageview(path, title);
-    this.universal.trackPageview(path, title);
+    for (var i=0; i < this.trackers.length; i++) {
+      this.trackers[i].trackPageview(path, title);
+    }
   };
 
   /*
@@ -27,14 +33,16 @@
     options.nonInteraction – Prevent event from impacting bounce rate
   */
   Tracker.prototype.trackEvent = function(category, action, options) {
-    this.classic.trackEvent(category, action, options);
-    this.universal.trackEvent(category, action, options);
+    for (var i=0; i < this.trackers.length; i++) {
+      this.trackers[i].trackEvent(category, action, options);
+    }
   };
 
   Tracker.prototype.trackShare = function(network) {
     var target = location.pathname;
-    this.classic.trackSocial(network, 'share', target);
-    this.universal.trackSocial(network, 'share', target);
+    for (var i=0; i < this.trackers.length; i++) {
+      this.trackers[i].trackSocial(network, 'share', target);
+    }
   };
 
   /*
@@ -42,15 +50,18 @@
     Check this for your app before using this
    */
   Tracker.prototype.setDimension = function(index, value, name, scope) {
-    this.universal.setDimension(index, value, name, scope);
-    this.classic.setDimension(index, value, name, scope);
+    for (var i=0; i < this.trackers.length; i++) {
+      this.trackers[i].setDimension(index, value, name, scope);
+    }
   };
 
   /*
    Add a beacon to track a page in another GA account on another domain.
    */
   Tracker.prototype.addLinkedTrackerDomain = function(trackerId, name, domain) {
-    this.universal.addLinkedTrackerDomain(trackerId, name, domain);
+    for (var i=0; i < this.trackers.length; i++) {
+      this.trackers[i].addLinkedTrackerDomain(trackerId, name, domain);
+    }
   };
 
   GOVUK.Tracker = Tracker;

--- a/spec/unit/analytics/TrackerSpec.js
+++ b/spec/unit/analytics/TrackerSpec.js
@@ -25,6 +25,26 @@ describe("GOVUK.Tracker", function() {
       expect(window._gaq[1]).toEqual(['_setDomainName', '.www.gov.uk']);
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {'cookieDomain': '.www.gov.uk'}]);
     });
+
+  });
+
+  describe('when created with only universal analytics', function() {
+    var universalSetupArguments;
+
+    beforeEach(function () {
+    });
+
+    it ('doesn\'t require both trackers to be present', function() {
+      universalOnlyConfig = { universalId: 'universal-id',
+                              cookieDomain: '.www.gov.uk'
+                            };
+
+      var tracker = new GOVUK.Tracker(universalOnlyConfig);
+
+      universalSetupArguments = window.ga.calls.allArgs();
+      expect(typeof(window._gaq[0])).toEqual('undefined');
+      expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {'cookieDomain': '.www.gov.uk'}]);
+    });
   });
 
   describe('when tracking pageviews, events and custom dimensions', function() {


### PR DESCRIPTION
This PR is preparatory work for: https://www.pivotaltracker.com/story/show/93551518


This PR makes it possible to use Tracker.js with only one of the analytics codes (classic or universal). Tracker.js currently expects both a universal code and a classic code but we are switching off classic a few apps at a time so Tracker.js should be not expect both codes or need them in order to work.

This PR:

- normalises the interfaces of `google-analytics-classic-tracker.js` and `google-analytics-universal-tracker.js` so that `Tracker.js` can treat them both generically as trackers.
- Changes Tracker.js to accept one or both or none of the analytics ids.

@fofr it would be cool if you could take a look at this, but anyone else's reckons also welcome.