### PR TITLE
Add link to example table using tabular numbers

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -350,6 +350,8 @@ Tabular numbers have numerals of a standard fixed width. As all numbers have the
       @include core-24($tabular-numbers: true);
     }
 
+[See an example of tabular numbers in a table](http://govuk-elements.herokuapp.com/#data-in-a-table)
+
 #### external links
 
 `external-link-default` sets up the background image for all external links.


### PR DESCRIPTION
This PR links to elements which includes an example table using tabular numbers.

I don't know if we link to elements in other cases, but it includes a lot of good use cases.