### PR TITLE
Update $error-colour variable to use existing colour palette

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -108,5 +108,5 @@ $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners
 $live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
-$error-colour: #af1324;           // Error text and border colour
+$error-colour: $red;              // Error text and border colour
 $error-background: #fef7f7;       // Error background colour


### PR DESCRIPTION
This change updates the $error-colour variable from #af1324 to the
existing $red colour variable #b10e1e, rather than introducing another,
similar shade of red.

#af1324 has a contrast ratio of 7:14:1, however, the palette already
has $red: #b10e1e; which has a contrast ratio of 7:12:1.

This colour should provide enough contrast between text and its
background so that it can be read by people with moderately low vision.