### PR TITLE
Proposal to fix JSLint Error for side effects

### DIFF
--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -19,7 +19,7 @@
       $elms = $(elmsOrSelector);
       this.selector = elmsOrSelector;
       this.setInitialState($(this.selector));
-    } else {
+    } else if ($elms !== undefined) {
       this.$elms = elmsOrSelector;
       this.setInitialState(this.$elms);
     }

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -19,7 +19,7 @@
       $elms = $(elmsOrSelector);
       this.selector = elmsOrSelector;
       this.setInitialState($(this.selector));
-    } else if ($elms !== undefined) {
+    } else if (elmsOrSelector !== undefined) {
       this.$elms = elmsOrSelector;
       this.setInitialState(this.$elms);
     }


### PR DESCRIPTION
I've been receiving a JSLint message "Do not use 'new' for side-effects." when used in this context:

```javascript
    new GOVUK.SelectionButtons($blockLabels);
```

This code is also available at: [MoJ - Accelerated Claims - line: 88](https://github.com/ministryofjustice/accelerated_claims/blob/34a625f713a0e488d8673db9bbc48d476c0e84a5/app/assets/javascripts/application.js.erb)

With the change I've made we would be able to achieve better LINTiness

```javascript
    var selectionButtons = new GOVUK.SelectionButtons();
    selectionButtons.$elms = $blockLabels;
    selectionButtons.setInitialState($blockLabels);
```

I would prefer a better pattern, such as an Initialise method (ideally chainable off the constructor) - but I'll take what I can get ;)