### PR TITLE
Stop multiline from dropping below phase tag

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -27,12 +27,9 @@
   }
 
   span {
-    @include inline-block;
-    width: 75%;
     vertical-align: top;
 
     @include media(tablet) {
-      width: auto;
       vertical-align: baseline;
     }
   }


### PR DESCRIPTION
Setting `display: inline-block` was causing the span to drop below the phase tag. Also removed `width` declarations as inline elements can’t have width set explicitly.

I also think the `vertical-align` statements could be removed as they don't seem to have any visual effect (in Chrome).

## Before

![screen shot 2015-06-02 at 15 29 34](https://cloud.githubusercontent.com/assets/523014/7938546/117798a6-093e-11e5-992d-b2439bd0d867.png)

## After

![screen shot 2015-06-02 at 15 29 46](https://cloud.githubusercontent.com/assets/523014/7938550/15680d42-093e-11e5-9b3b-5bc3fd288c61.png)
