### PR TITLE
Stop banner text from running full width

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -20,6 +20,11 @@
     margin: 0;
     color: $banner-text-colour;
     @include core-16;
+    line-height: (22/16);
+
+    @include media(tablet) {
+      max-width: $two-thirds;
+    }
   }
 
   .phase-tag {


### PR DESCRIPTION
## Before

![screen shot 2015-06-10 at 14 03 34](https://cloud.githubusercontent.com/assets/523014/8083030/b53773c6-0f79-11e5-8c4f-367c750fb963.png)

## After

![screen shot 2015-06-10 at 14 04 02](https://cloud.githubusercontent.com/assets/523014/8083048/bc32f1fa-0f79-11e5-9a35-f824da9fb0bd.png)
