### PR TITLE
Use grid layout mixins

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -10,11 +10,12 @@
 // }
 
 @mixin phase-banner($state: alpha) {
+
+  @extend %contain-floats;
+  @extend %grid-row;
+
   padding: 10px 0 8px 0;
-  @include media(tablet) {
-    padding-bottom: 10px;
-  }
-  border-bottom: 1px solid $border-colour;
+  position: relative;
 
   p {
     margin: 0;
@@ -22,8 +23,19 @@
     @include core-16;
     line-height: (22/16);
 
+    @include grid-column(1);
     @include media(tablet) {
-      max-width: $two-thirds;
+      @include grid-column(2/3);
+    }
+
+    &:after {
+      content: "";
+      border-bottom: 1px solid $border-colour;
+
+      position: absolute;
+      bottom: 0;
+      left: 15px;
+      right: 15px;
     }
   }
 
@@ -32,11 +44,7 @@
   }
 
   span {
-    vertical-align: top;
-
-    @include media(tablet) {
-      vertical-align: baseline;
-    }
+    vertical-align: bottom;
   }
 }
 


### PR DESCRIPTION
Use the grid layout mixins from the front end toolkit, so that phase
banner content is the same width as the GOV.UK main content area, (2/3)
width of the page.

- Set phase banner wrapper to use the grid-row placeholder
- Set paragraph text to be the same width as grid-column(2/3)
- Use generated content to add the bottom border
[http://caniuse.com/#search=%3Aafter] for a bottom border in IE8 and
up.