### PR TITLE
Add support for sending page option when tracking events

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -90,6 +90,7 @@ Argument | Description
 
 Option | Description
 -------|------------
+`page`  | Useful for sending the URL when `window.location` has been updated using JavaScript since the Analytics tracking object was created
 `label` | Useful for categorising events, eg Javascript error source
 `value` | Values must be non-negative. Useful to pass counts, eg error happened 5 times
 `nonInteraction` | Defaults to false. When set the event will not affect bounce rate
@@ -98,8 +99,9 @@ Option | Description
 // Track a custom event with required category and action fields
 GOVUK.analytics.trackEvent('category', 'action');
 
-// Track a custom event with optional label, value and nonInteraction options
+// Track a custom event with optional page, label, value and nonInteraction options
 GOVUK.analytics.trackEvent('category', 'action', {
+  page: '/path/to/page',
   label: 'label',
   value: 1,
   nonInteraction: true // event will not affect bounce rate

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -54,6 +54,11 @@
       evt.eventLabel = options.label;
     }
 
+    // Page is optional
+    if (typeof options.page === "string") {
+      evt.page = options.page;
+    }
+
     // Value is optional, but when used must be an
     // integer, otherwise the event will be invalid
     // and not logged

--- a/spec/unit/analytics/GoogleAnalyticsUniversalTrackerSpec.js
+++ b/spec/unit/analytics/GoogleAnalyticsUniversalTrackerSpec.js
@@ -94,6 +94,13 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
         }]
       );
     });
+
+    it('sends the page if supplied', function() {
+      universal.trackEvent('category', 'action', {page: '/path/to/page'});
+      expect(window.ga.calls.mostRecent().args).toEqual(
+        ['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action', page: '/path/to/page'}]
+      );
+    });
   });
 
   describe('when social events are tracked', function() {


### PR DESCRIPTION
This adds support for sending the `page` option to `ga()` when tracking
events[1].

We're trying to use events to track when people reach an outcome in Smart
Answers[2]. The current set-up is giving us inaccurate data because of the use
of JavaScript to partially replace pages as a user navigates the Smart Answer:
The majority of the events are being recorded against the start page of the
Smart Answer (e.g. /student-finance-forms/y) instead of the outcome page.

I've got an open pull request in Smart Answers that switches us to use `ga()`
directly so that I can test whether sending the `page` option actually gives us
the data we're interested in[3]. Assuming it does then I think the right thing
to do is add support for `page` in this project.

[1]: https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation
[2]: https://github.com/alphagov/smart-answers/commit/5d09931ce02c65ce1ca255f74960e1ee4ec2681e
[3]: https://github.com/alphagov/smart-answers/pull/1787