### PR TITLE
Tag the repo when version is changed

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,3 +3,21 @@ set -e
 
 npm install
 npm test
+
+# Create a new tag if the version file has been updated and a tag for that
+# version doesn't already exist
+
+# Are we on master branch, we shouldn't push tags for version bump branches
+MASTER_SHA=`git rev-parse origin/master`
+HEAD_SHA=`git rev-parse HEAD`
+if [ "$MASTER_SHA" == "$HEAD_SHA" ]; then
+  # get the version from the version file
+  VERSION_TAG="v`cat VERSION.TXT`"
+
+  # check to make sure the tag doesn't already exist
+  if ! git rev-parse $VERSION_TAG >/dev/null 2>&1; then
+    echo "Creating new tag: $VERSION_TAG"
+    git tag $VERSION_TAG
+    git push origin $VERSION_TAG
+  fi
+fi


### PR DESCRIPTION
When we make a change to the version file we automatically create and
publish new versions of the toolkit packages.

This change will then also create a tag on this repository with the new
version number.

This has two benefits. It will be much easier to view the differences
between versions as we can just look at the changes between friendly tag
names. The other benefit is things like bower can pull in a specific tag
rather than a sha.

This should fix #204 