### PR TITLE
Bundle before running tests

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -e
 
+bundle install
 npm install
 npm test
 


### PR DESCRIPTION
The tests rely upon the Sass gem. Run bundle before running tests so
that the Sass gem is available.