### PR TITLE
Proposal to fix JSLint Error for side effects

### DIFF
--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -19,7 +19,7 @@
       $elms = $(elmsOrSelector);
       this.selector = elmsOrSelector;
       this.setInitialState($(this.selector));
-    } else {
+    } else if (elmsOrSelector !== undefined) {
       this.$elms = elmsOrSelector;
       this.setInitialState(this.$elms);
     }


### PR DESCRIPTION
The JSLint error is:

["Do not use 'new' for side-effects."](https://jslinterrors.com/do-not-use-new-for-side-effects).

This change allows you to store the resulting
instance in a variable by calling the constructor
without any arguments.

This kind of use would mean the setting of the
`$elms` property and the calling of the
`setInitialState` method would still be required
for all behaviours to work correctly, for example:

```
var selectionButtons = new GOVUK.SelectionButtons();
selectionButtons.$elms = $blockLabels;
selectionButtons.setInitialState($blockLabels);
```

Credit to [worktick](https://github.com/worktick) for this work (see [#196](https://github.com/alphagov/govuk_frontend_toolkit/pull/196)).