### PR TITLE
Switch download tracking to use events

### DIFF
--- a/javascripts/govuk/analytics/download-link-tracker.js
+++ b/javascripts/govuk/analytics/download-link-tracker.js
@@ -12,9 +12,14 @@
     function trackDownload(evt) {
       var $link = getLinkFromEvent(evt),
           href = $link.attr('href'),
+          evtOptions = {transport: 'beacon'},
           linkText = $.trim($link.text());
 
-      GOVUK.analytics.trackPageview(href, linkText, {transport: 'beacon'});
+      if (linkText) {
+        evtOptions.label = linkText;
+      }
+
+      GOVUK.analytics.trackEvent('Download Link Clicked', href, evtOptions);
     }
 
     function getLinkFromEvent(evt) {

--- a/spec/unit/analytics/DownloadLinkTrackerSpec.js
+++ b/spec/unit/analytics/DownloadLinkTrackerSpec.js
@@ -16,7 +16,7 @@ describe("GOVUK.analyticsPlugins.downloadLinkTracker", function() {
 
     $('html').on('click', function(evt) { evt.preventDefault(); });
     $('body').append($links);
-    GOVUK.analytics = {trackPageview:function(){}};
+    GOVUK.analytics = {trackEvent:function(){}};
     GOVUK.analyticsPlugins.downloadLinkTracker({selector: 'a[href$=".pdf"], a[href$=".xslt"], a[href$=".doc"], a[href$=".png"]'});
   });
 
@@ -28,34 +28,37 @@ describe("GOVUK.analyticsPlugins.downloadLinkTracker", function() {
   });
 
   it('listens to clicks on links that match the selector', function() {
-    spyOn(GOVUK.analytics, 'trackPageview');
+    spyOn(GOVUK.analytics, 'trackEvent');
 
     $('.download-links a').each(function() {
       $(this).trigger('click');
-      expect(GOVUK.analytics.trackPageview).toHaveBeenCalled();
-      GOVUK.analytics.trackPageview.calls.reset();
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+      GOVUK.analytics.trackEvent.calls.reset();
     });
 
     $('.normal-links a').each(function() {
       $(this).trigger('click');
-      expect(GOVUK.analytics.trackPageview).not.toHaveBeenCalled();
-      GOVUK.analytics.trackPageview.calls.reset();
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+      GOVUK.analytics.trackEvent.calls.reset();
     });
   });
 
   it('listens to click events on elements within download links', function() {
-    spyOn(GOVUK.analytics, 'trackPageview');
+    spyOn(GOVUK.analytics, 'trackEvent');
 
     $('.download-links a img').trigger('click');
-    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith('/an/image/link.png', '', {transport: 'beacon'});
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Download Link Clicked', '/an/image/link.png', {transport: 'beacon'});
   });
 
-  it('tracks a download link as a pageview with a custom title', function() {
-    spyOn(GOVUK.analytics, 'trackPageview');
+  it('tracks a download link as an event with link text as the label', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
     $('.download-links a').trigger('click');
 
-    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith('/one.pdf', 'PDF', {transport: 'beacon'});
-    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith('/two.xslt', 'Spreadsheet', {transport: 'beacon'});
-    expect(GOVUK.analytics.trackPageview).toHaveBeenCalledWith('/something/uploads/system/three.doc', 'Document', {transport: 'beacon'});
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Download Link Clicked', '/one.pdf', {label: 'PDF', transport: 'beacon'});
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Download Link Clicked', '/two.xslt', {label: 'Spreadsheet', transport: 'beacon'});
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Download Link Clicked', '/something/uploads/system/three.doc', {label: 'Document', transport: 'beacon'});
   });
 });


### PR DESCRIPTION
Events show a user intent, but are less likely to be interpreted incorrectly – it shows that a user clicked a link on a page, rather than the file was successfully downloaded and viewed.

It should avoid inflating our pageview numbers, prevent an increase in our cardinality and leave open a more complete pageview tracking solution from logs (eg for direct downloads).