### PR TITLE
‘depricated’ should be ‘deprecated’

### DIFF
--- a/stylesheets/_grid_layout.scss
+++ b/stylesheets/_grid_layout.scss
@@ -100,12 +100,12 @@ $site-width: 960px;
 }
 
 
-// OLD depricated grid mixins
+// OLD deprecated grid mixins
 // You should migrate to the mixins above in the future
 
 // Outer block sets a max width
 @mixin outer-block {
-  @warn "The @mixin outer-block is depricated and should be updated to new grid helpers";
+  @warn "The @mixin outer-block is deprecated and should be updated to use new grid helpers";
   margin: 0 auto;
   width: auto;
   max-width: 960 + $gutter*2;
@@ -118,7 +118,7 @@ $site-width: 960px;
 // Inner block sets either margin or padding
 // to align content with header and footer
 @mixin inner-block($margin-or-padding: padding) {
-  @warn "The @mixin inner-block is depricated and should be updated to use new grid helpers";
+  @warn "The @mixin inner-block is deprecated and should be updated to use new grid helpers";
   #{$margin-or-padding}-left: $gutter-half;
   #{$margin-or-padding}-right: $gutter-half;
   @include media(tablet) {


### PR DESCRIPTION
Simple mis-spelling, but it jumps out at me on every project that uses the old @mixins.