### PR TITLE
Allow the toolkit font to be changed

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -286,6 +286,15 @@ A collection of font-mixins. There are two different types of font mixins.
    consistent baseline vertical grid.
 2. Core styles which are base font styles with no extra padding.
 
+#### Changing font
+
+Typography mixins use a “New Transport” font stack by default.
+
+If you are using the toolkit on projects that aren’t GOVUK branded you can
+override the font using two variables: `$toolkit-font-stack` and
+`$toolkit-font-stack-tabular`. These must be declared before they are used, eg by
+the core typography mixins.
+
 #### Heading and Copy styles
 
 The following heading and copy styles exist:

--- a/stylesheets/_font_stack.scss
+++ b/stylesheets/_font_stack.scss
@@ -1,6 +1,5 @@
 //  GOV.UK font stacks, referred to in typography.scss
 
-
 //  Font stack weirdness
 //
 //  To ensure embedded fonts fall back to appropriate
@@ -14,22 +13,15 @@
 // scss-lint:disable NameFormat
 
 // New Transport Light
+$NTA-Light: "nta", Arial, sans-serif;
+$NTA-Light-Tabular: "ntatabularnumbers", $NTA-Light;
 
-$NTA-Light:
-  "nta",
-  Arial,
-  sans-serif;
-
-// New Transport Light with Tabular
-
-$NTA-Light-Tabular:
-  "ntatabularnumbers",
-  "nta",
-  Arial,
-  sans-serif;
+// Allow font stack to be overridden
+// Not all apps using toolkit use New Transport
+$toolkit-font-stack: $NTA-Light !default;
+$toolkit-font-stack-tabular: $NTA-Light-Tabular !default;
 
 // Helvetica Regular
-
 @font-face {
   font-family: GDS-Logo;
   src: local("HelveticaNeue"),
@@ -38,10 +30,7 @@ $NTA-Light-Tabular:
        local("Helvetica");
 }
 
-$Helvetica-Regular:
-  "GDS-Logo",
-  sans-serif;
+$Helvetica-Regular: "GDS-Logo", sans-serif;
 
 // Font reset for print
-
 $Print-reset: sans-serif;

--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -22,11 +22,11 @@ $is-print: false !default;
 
 @mixin _core-font-generator($font-size: 19px, $font-size-640: 16px, $font-size-print: 14pt, $line-height: (25 / 19), $line-height-640: (20 / 16), $tabular-numbers: false, $font-weight: 400) {
   @if $tabular-numbers == true {
-    font-family: $NTA-Light-Tabular;
+    font-family: $toolkit-font-stack-tabular;
   } @else if $is-print {
     font-family: $Print-reset;
   } @else {
-    font-family: $NTA-Light;
+    font-family: $toolkit-font-stack;
   }
   font-size: $font-size-640;
   line-height: $line-height-640;


### PR DESCRIPTION
Some projects, such as petitions and admin tools aren’t GOVUK branded but still use the toolkit. These projects sometimes can’t use New Transport, or choose not to.

* Make it easy to switch out the font used
* Add documentation
* Write font stacks on single line as that’s how they are usually
presented in CSS, etc.

cc @quis @robinwhittleton