### PR TITLE
Use the light blue Sass variable for link active and hover colours

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -91,8 +91,8 @@ $white: #fff;
 
 // Semantic colour names
 $link-colour: $govuk-blue;
-$link-active-colour: #2e8aca;
-$link-hover-colour: #2e8aca;
+$link-active-colour: $light-blue;
+$link-hover-colour: $light-blue;
 $link-visited-colour: #4c2c92;
 $button-colour: #00823b;
 $focus-colour: $yellow;


### PR DESCRIPTION
Currently we have:
![colour gov uk elements - hover](https://cloud.githubusercontent.com/assets/417754/12617108/1c799766-c506-11e5-9325-ae940e11e8b6.png)

![colour gov uk elements - light blue](https://cloud.githubusercontent.com/assets/417754/12617111/1e4bc73a-c506-11e5-8dfc-955a4390db63.png)

This PR uses the `$light-blue` Sass variable for both link active and hover colours, `#2b8cc4`.

This fixes #240.
