### PR TITLE
Add tracking of click events on mailto links

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ In production:
   * [Error tracking](/docs/analytics.md#error-tracking-error-trackingjs)
   * [External link tracking](/docs/analytics.md#external-link-tracking-external-link-trackerjs)
   * [Download link tracking](/docs/analytics.md#download-link-tracking-download-link-trackerjs)
+  * [Mailto link tracking](/docs/analytics.md#mailto-link-tracking-mailto-link-trackerjs)
 
 ## Licence
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -202,3 +202,12 @@ GOVUK.analyticsPlugins.downloadTracker({selector: 'a[rel="download"]'});
 Category | Action | Label
 ---------|--------|-------
 Download Link Clicked | `/some/upload/attachment/file.pdf` | Link text
+
+### Mailto link tracking (`mailto-link-tracker.js`)
+
+The tracker will send events for clicks on links beginning with `mailto`. By default the
+plugin uses Google Analytics’ `transport: beacon` method so that events are tracked even if the page unloads.
+
+Category | Action | Label
+---------|--------|-------
+Mailto Link Clicked | mailto:name@email.com | Link text

--- a/javascripts/govuk/analytics/mailto-link-tracker.js
+++ b/javascripts/govuk/analytics/mailto-link-tracker.js
@@ -1,0 +1,33 @@
+(function() {
+  "use strict";
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
+  GOVUK.analyticsPlugins.mailtoLinkTracker = function () {
+
+    var mailtoLinkSelector = 'a[href^="mailto:"]';
+
+    $('body').on('click', mailtoLinkSelector, trackClickEvent);
+
+    function trackClickEvent(evt) {
+      var $link = getLinkFromEvent(evt),
+          options = {transport: 'beacon'},
+          href = $link.attr('href'),
+          linkText = $.trim($link.text());
+
+      if (linkText) {
+        options.label = linkText;
+      }
+
+      GOVUK.analytics.trackEvent('Mailto Link Clicked', href, options);
+    }
+
+    function getLinkFromEvent(evt) {
+      var $target = $(evt.target);
+
+      if (!$target.is('a')) {
+        $target = $target.parents('a');
+      }
+
+      return $target;
+    }
+  }
+}());

--- a/spec/manifest.js
+++ b/spec/manifest.js
@@ -13,7 +13,8 @@ var manifest = {
     '../../javascripts/govuk/analytics/analytics.js',
     '../../javascripts/govuk/analytics/error-tracking.js',
     '../../javascripts/govuk/analytics/external-link-tracker.js',
-    '../../javascripts/govuk/analytics/download-link-tracker.js'
+    '../../javascripts/govuk/analytics/download-link-tracker.js',
+    '../../javascripts/govuk/analytics/mailto-link-tracker.js'
   ],
   test : [
     '../unit/modules.spec.js',
@@ -26,6 +27,7 @@ var manifest = {
     '../unit/analytics/analytics.spec.js',
     '../unit/analytics/error-tracking.spec.js',
     '../unit/analytics/external-link-tracker.spec.js',
-    '../unit/analytics/download-link-tracker.spec.js'
+    '../unit/analytics/download-link-tracker.spec.js',
+    '../unit/analytics/mailto-link-tracker.spec.js'
   ]
 };

--- a/spec/unit/analytics/mailto-link-tracker.spec.js
+++ b/spec/unit/analytics/mailto-link-tracker.spec.js
@@ -1,0 +1,54 @@
+describe("GOVUK.analyticsPlugins.mailtoLinkTracker", function() {
+  var $links;
+
+  beforeEach(function() {
+    $links = $('\
+      <div class="mailto-links">\
+        <a href="mailto:name1@email.com"></a>\
+        <a href="mailto:name2@email.com">The link for a mailto</a>\
+        <a href="mailto:name3@email.com"><img src="/img" /></a>\
+      </div>');
+
+    $('html').on('click', function(evt) { evt.preventDefault(); });
+    $('body').append($links);
+    GOVUK.analytics = {trackEvent:function(){}};
+
+    GOVUK.analyticsPlugins.mailtoLinkTracker();
+  });
+
+  afterEach(function() {
+    $('html').off();
+    $('body').off();
+    $links.remove();
+    delete GOVUK.analytics;
+  });
+
+  it('listens to click events on mailto links', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    $('.mailto-links a').each(function() {
+      $(this).trigger('click');
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled();
+      GOVUK.analytics.trackEvent.calls.reset();
+    });
+  });
+
+  it('tracks mailto addresses and link text', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+    $('.mailto-links a').trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Mailto Link Clicked', 'mailto:name1@email.com', {transport: 'beacon'});
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Mailto Link Clicked', 'mailto:name2@email.com', {transport: 'beacon', label: 'The link for a mailto'});
+  });
+
+  it('listens to click events on elements within mailto links', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    $('.mailto-links a img').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'Mailto Link Clicked', 'mailto:name3@email.com', {transport: 'beacon'});
+  });
+});


### PR DESCRIPTION
Not sure on the best way to share functions between external-link-tracker.js and mailto-link-tracker.js, other than the category value passed to trackEvent, the two functions in each file are essentially identical