### PR TITLE
Update defra green

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -195,7 +195,7 @@ A collection of colour variables.
 * `$department-for-communities-and-local-government` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #00857e" />
 * `$department-for-energy-and-climate-change` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #009ddb" />
 * `$department-for-culture-media-and-sport` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #d40072" />
-* `$department-for-environment-food-and-rural-affairs` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #898700" />
+* `$department-for-environment-food-and-rural-affairs` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #00a33b" />
 * `$department-for-work-and-pensions` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #00beb7" />
 * `$department-for-business-innovation-and-skills` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #003479" />
 * `$department-for-international-development` <span style="display:inline-block; width: 60px; height: 10px; float: right; background-color: #002878" />

--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -9,7 +9,7 @@ $department-for-business-innovation-skills: #003479;
 $department-for-communities-and-local-government: #00857e;
 $department-for-culture-media-sport: #d40072;
 $department-for-education: #003a69;
-$department-for-environment-food-rural-affairs: #898700;
+$department-for-environment-food-rural-affairs: #00a33b;
 $department-for-international-development: #002878;
 $department-for-transport: #006c56;
 $department-for-work-pensions: #00beb7;


### PR DESCRIPTION
Switch to the new green, which is more neon and is web safe by default.
https://trello.com/c/p3BYq1Rd/295-defra-colour-change-to-brand

![screen shot 2016-02-16 at 14 14 23](https://cloud.githubusercontent.com/assets/319055/13078537/9cbeab76-d4b7-11e5-9cf1-a54723a40cca.png)

