### PR TITLE
Add a new Sass variable $footer-background

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -103,6 +103,7 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
+$footer-background: $grey-3;      // GOV.UK footer background colour
 $discovery-colour: $fuschia;      // Discovery badges and banners
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners


### PR DESCRIPTION
Add a new Sass variable for the GOV.UK template's $footer-background.

The govuk_template uses `$grey-8` in `/styleguide/colours.scss`.

Since `$grey-8` is the same as `$grey-3` from the front end toolkit = `#dee0e2`, but `$grey-3` is overridden by the govuk template - in `/styleguide/colours.scss` (line 10), create a new variable $footer-background to be used by the template.
