### PR TITLE
Pass cohort name to universal analytics set dimension

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -248,7 +248,7 @@ var test = new GOVUK.MultivariateTest({
 });
 ```
 
-`customDimensionIndex` is the index of the custom variable in Google Analytics. GA only gives 50 integer slots to each account, and it is important that a unique integer is assigned to each test. Current contact for assigning a custom var slot for GOV.UK is: Ashraf Chohan <ashraf.chohan@digital.cabinet-office.gov.uk>
+`customDimensionIndex` is the index of the custom variable in Google Analytics. GA only gives 50 integer slots to each account, and it is important that a unique integer is assigned to each test. Current contact for assigning a custom var slot for GOV.UK is: Tim Leighton-Boyce <tim.leighton-boyce@digital.cabinet-office.gov.uk>
 
 ## Primary Links
 

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -77,9 +77,7 @@
     if (this.customDimensionIndex) {
       GOVUK.analytics.setDimension(
         this.customDimensionIndex,
-        this.cookieName(),
-        cohort,
-        2 // session level
+        this.cookieName() + "__" + cohort
       );
     }
   };

--- a/spec/unit/multivariate-test.spec.js
+++ b/spec/unit/multivariate-test.spec.js
@@ -47,7 +47,7 @@ describe("MultivariateTest", function() {
       expect(fooSpy).toHaveBeenCalled();
     });
 
-    it("should set a custom var if one is defined", function() {
+    it("should set a custom var with the name and cohort if one is defined", function() {
       GOVUK.cookie.and.returnValue('foo');
       var test = new GOVUK.MultivariateTest({
         name: 'stuff',
@@ -59,10 +59,19 @@ describe("MultivariateTest", function() {
       });
       expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(
         2,
-        'multivariatetest_cohort_stuff',
-        'foo',
-        2
+        'multivariatetest_cohort_stuff__foo'
       );
+    });
+
+    it("should trigger an event to track that the test has been run", function() {
+      GOVUK.cookie.and.returnValue('foo');
+      var test = new GOVUK.MultivariateTest({
+        name: 'stuff',
+        cohorts: {
+          foo: {},
+          bar: {}
+        },
+      });
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
         'multivariatetest_cohort_stuff',
         'run',


### PR DESCRIPTION
During testing of alphagov/smart-answers#2265 we noticed that only the test name was being sent to GA for our custom dimension where we expected to see the cohort name too.  After a bit of digging we found that the `MultivariateTest` had not been updated since we removed the classic GA tracker analytics implementation.  Old dimensions allowed 4 arguments: the dimension index, a name (this was the name of the test), a value (this was the name of the cohort), and a scope for the data to be set in (this was session scope); whereas new dimensions allow only 2 arguments: the dimension index and a piece of custom data (because all other arguments were ignored this was just the name of the test).

We want to pass on the name of the cohort to the dimension so we change the call to set dimension from the `MultivariateTest` to combine the test name and the cohort name and send this as the 2nd argument to the call.

While we're at it we update the contact details for the person to communicate with about creating new custom dimensions as it's no longer Ashraf.

/cc @benilovj, @fofr 