### PR TITLE
Remove link to http://alphagov.github.com/design/

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -1,5 +1,4 @@
-// Colours for the site, as per:
-// http://alphagov.github.com/design/gov.uk.colours/
+// Colours for the site
 
 // Departmental colours
 $attorney-generals-office: #9f1888;


### PR DESCRIPTION
The information here is out of date, remove this link from the frontend
toolkit.