### PR TITLE
Remove alias for footer background

### DIFF
--- a/stylesheets/_colours.scss
+++ b/stylesheets/_colours.scss
@@ -102,7 +102,6 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$footer-background: $grey-3;      // GOV.UK footer background colour
 $discovery-colour: $fuschia;      // Discovery badges and banners
 $alpha-colour: $pink;             // Alpha badges and banners
 $beta-colour: $orange;            // Beta badges and banners


### PR DESCRIPTION
This Sass variable `$footer-background` should remain with the [GOV.UK template’s colour
variables](https://github.com/alphagov/govuk_template/pull/201/files).

cc. @dsingleton.