### PR TITLE
Improve phase banner text wrapping

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -22,6 +22,7 @@
     margin: 0;
     color: $banner-text-colour;
     @include core-16;
+    @extend %contain-floats;
   }
 
   .phase-tag {
@@ -29,6 +30,7 @@
   }
 
   span {
+    display: block;
     vertical-align: top;
 
     @include media(tablet) {
@@ -50,7 +52,8 @@
 // }
 
 @mixin phase-tag($state: alpha) {
-  @include inline-block;
+  display: block;
+  float: left;
   vertical-align: top;
 
   @include media(tablet) {


### PR DESCRIPTION
Previously the text block wrapped below the phase tag, and the ascenders were bumping up against the phase tag.

The change means the text wraps under itself, avoiding the phase tag.

Before:
<img width="405" alt="screen shot 2016-03-03 at 10 55 34" src="https://cloud.githubusercontent.com/assets/523014/13492697/8e5dd698-e131-11e5-822b-c7d2c2808324.png">

After:
<img width="405" alt="screen shot 2016-03-03 at 10 54 40" src="https://cloud.githubusercontent.com/assets/523014/13492700/94359ccc-e131-11e5-9bdb-c3d66743914a.png">
