### PR TITLE
Improve phase banner alignment

### DIFF
--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -29,11 +29,7 @@
   }
 
   span {
-    vertical-align: top;
-
-    @include media(tablet) {
-      vertical-align: baseline;
-    }
+    vertical-align: baseline;
   }
 }
 
@@ -51,12 +47,6 @@
 
 @mixin phase-tag($state: alpha) {
   @include inline-block;
-  vertical-align: top;
-
-  @include media(tablet) {
-    vertical-align: baseline;
-  }
-
   margin: 0 8px 0 0;
   padding: 2px 5px 0;
 

--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -19,6 +19,7 @@
   border-bottom: 1px solid $border-colour;
 
   p {
+    display: table;
     margin: 0;
     color: $banner-text-colour;
     @include core-16;
@@ -29,6 +30,7 @@
   }
 
   span {
+    display: table-cell;
     vertical-align: baseline;
   }
 }


### PR DESCRIPTION
At smaller screen sizes, the phase banner text wraps underneath the phase tag.

Screenshot before:

![gov uk elements - phase banner](https://cloud.githubusercontent.com/assets/417754/13673479/148f6278-e6d1-11e5-874f-1f09a9770e67.png)

This PR fixes this, by setting the parent paragraph to `display:table` and the line of text next to the phase tag to `display:table-cell`.

An alternative would be to use flexbox (as suggested by @alextea):

```
  p {
    display: flex;
    align-items: baseline;
  }
```
IE10 requires a prefix, uses a different syntax and doesn't work as well.

Without modifying the GOV.UK template, there isn't a way to target versions of IE greater than 8, or a way to test for a browsers' features.

Screenshots after:

iPhone 6

![realios_iphone_6](https://cloud.githubusercontent.com/assets/417754/13673899/159a80b0-e6d3-11e5-8a43-0d5e8958d239.jpg)

Windows 10, IE11

![win10_ie_11 0](https://cloud.githubusercontent.com/assets/417754/13673884/06d566f8-e6d3-11e5-9887-b67963860f38.jpg)

Windows 7, IE8

![win7_ie_8 0](https://cloud.githubusercontent.com/assets/417754/13673877/f937e94e-e6d2-11e5-8c2a-379ddae06f74.jpg)





