### PR TITLE
Set default flag on font variables

### DIFF
--- a/stylesheets/_font_stack.scss
+++ b/stylesheets/_font_stack.scss
@@ -18,7 +18,8 @@
 $NTA-Light:
   "nta",
   Arial,
-  sans-serif;
+  sans-serif
+  !default;
 
 // New Transport Light with Tabular
 
@@ -26,7 +27,8 @@ $NTA-Light-Tabular:
   "ntatabularnumbers",
   "nta",
   Arial,
-  sans-serif;
+  sans-serif
+  !default;
 
 // Helvetica Regular
 


### PR DESCRIPTION
I've had an [issue open](https://github.com/alphagov/govuk_template/issues/207) on govuk_template regarding the NTA font not containing international characters. I've been provided with a new font, "nta-extended", which contains a bigger character set. However, I can't override the font in the toolkit as when importing [_typography.scss](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_typography.scss) it imports font_stack, setting the font back to the standard "nta". By using the `!default` flag, the font can be overwritten before importing the toolkit sass files, and it won't be set back to "nta".
