### PR TITLE
Stop CSS being output into a consuming project simply by including partials

### DIFF
--- a/stylesheets/_conditionals.scss
+++ b/stylesheets/_conditionals.scss
@@ -25,14 +25,6 @@
 $is-ie: false !default;
 $mobile-ie6: true !default;
 
-@-ms-viewport {
-  width: device-width;
-}
-
-@-o-viewport {
-  width: device-width;
-}
-
 @mixin media($size: false, $max-width: false, $min-width: false, $ignore-for-ie: false) {
   @if $is-ie and ($ignore-for-ie == false) {
     @if $size != mobile {

--- a/stylesheets/_font_stack.scss
+++ b/stylesheets/_font_stack.scss
@@ -16,21 +16,13 @@
 $NTA-Light: "nta", Arial, sans-serif;
 $NTA-Light-Tabular: "ntatabularnumbers", $NTA-Light;
 
+// Helvetica Regular
+$Helvetica-Regular: "HelveticaNeue", "Helvetica Neue", "Arial", "Helvetica", sans-serif;
+
 // Allow font stack to be overridden
 // Not all apps using toolkit use New Transport
 $toolkit-font-stack: $NTA-Light !default;
 $toolkit-font-stack-tabular: $NTA-Light-Tabular !default;
-
-// Helvetica Regular
-@font-face {
-  font-family: GDS-Logo;
-  src: local("HelveticaNeue"),
-       local("Helvetica Neue"),
-       local("Arial"),
-       local("Helvetica");
-}
-
-$Helvetica-Regular: "GDS-Logo", sans-serif;
 
 // Font reset for print
 $Print-reset: sans-serif;


### PR DESCRIPTION
govuk_frontend_toolkit currently outputs a few declarations when you include the files. These can either be removed or migrated to govuk_template. Specifically, this PR removes the @font-face declaration for Helvetica, and removes the @viewport declarations (they’re added back in to govuk_template in https://github.com/alphagov/govuk_template/pull/212).