### PR TITLE
WIP: Redefine $link-colour for better contrast

### DIFF
--- a/stylesheets/colours/_palette.scss
+++ b/stylesheets/colours/_palette.scss
@@ -55,7 +55,7 @@ $grey-4: #f8f8f8;
 $white: #fff;
 
 // Semantic colour names
-$link-colour: $govuk-blue;
+$link-colour: #00579a; // $govuk-blue with better contrast ratio
 $link-active-colour: $light-blue;
 $link-hover-colour: $light-blue;
 $link-visited-colour: #4c2c92;


### PR DESCRIPTION
Part of the A11Y Hack day, originally raised by Richard Morton.

Issue is present with the contrast between the focus style background-color and the default link color.

The change is subtle compared with $govuk-blue but passes WCAG 2.0 Level AA

Before
![old](https://cloud.githubusercontent.com/assets/2445413/15320805/55e96438-1c2a-11e6-87f8-68151f2e6e43.png)

After
![new](https://cloud.githubusercontent.com/assets/2445413/15320806/55e97716-1c2a-11e6-91d7-1478c8d73992.png)
