### PR TITLE
Consistent button padding

### DIFF
--- a/stylesheets/design-patterns/_buttons.scss
+++ b/stylesheets/design-patterns/_buttons.scss
@@ -27,7 +27,7 @@
   // Size and shape
   position: relative;
   @include inline-block;
-  padding: 0.3em 0.6em 0.2em;
+  padding: .526315em .789473em .263157em; // 10px 15px 5px
   border: none;
   @include border-radius(0);
   -webkit-appearance: none;


### PR DESCRIPTION
This padding was originally set in GOVUK Elements button class instead it should have been be referenced in GOVUK Frontend Toolkits Button mixin.

Original issue: https://github.com/alphagov/govuk_elements/issues/228
GOVUK Elements PR: https://github.com/alphagov/govuk_elements/pull/230