### PR TITLE
Ignore the automatically genererated SASS test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .sass-cache
 npm-debug.log
-/spec/stylesheets/test-out.css.map
+spec/stylesheets


### PR DESCRIPTION
To test for syntax errors in the `scss` files we generate a temp
SASS file which includes all our scss files in `stylesheets/`, which
catches syntax errors in the top level declarations of those files.

Ignore the directory the tmp file is created in, not just the output.
Otherwise the test file/dir exists after running `npm test` and
could be accidentally commited.