### PR TITLE
Add js for finding and starting govuk modules

### DIFF
--- a/javascripts/govuk/start-modules.js
+++ b/javascripts/govuk/start-modules.js
@@ -1,0 +1,5 @@
+// https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/javascript.md#modules
+
+$(document).ready(function(){
+  GOVUK.modules.start();
+});


### PR DESCRIPTION
This is [being used by GOV.UK elements](https://github.com/alphagov/govuk_elements/pull/183/commits/22f9c130c5741daa06da02220895040d21c9d0e0), it _feels_ like it should sit in the front-end toolkit, as we have an example of this code here too. 

For now, this file adds javascript to [match the example js from the docs](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/java
script.md#modules).