### PR TITLE
Force push tracking branch on new version

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -22,6 +22,6 @@ if [ "$MASTER_SHA" == "$HEAD_SHA" ]; then
     git push origin $VERSION_TAG
 
     # Alias branch for the most recently released tag, for easier diffing
-    git push origin master:latest-release
+    git push -f origin master:latest-release
   fi
 fi


### PR DESCRIPTION
This was failing as a regular push, and causing the build to fail, even through the
tag was created on this repo, but not trigger the downstream jobs that package/
publish the gem/npm versions themselves