### PR TITLE
Allow base scripts to run within a module loader

### DIFF
--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -1,6 +1,7 @@
-(function() {
+(function(global) {
   "use strict";
-  window.GOVUK = window.GOVUK || {};
+
+  var GOVUK = global.GOVUK || {};
 
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
@@ -61,4 +62,6 @@
   };
 
   GOVUK.Analytics = Analytics;
-})();
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/download-link-tracker.js
+++ b/javascripts/govuk/analytics/download-link-tracker.js
@@ -1,5 +1,8 @@
-(function() {
+(function(global) {
   "use strict";
+
+  var GOVUK = global.GOVUK || {};
+
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
   GOVUK.analyticsPlugins.downloadLinkTracker = function (options) {
     var options = options || {},
@@ -32,4 +35,6 @@
       return $target;
     }
   }
-}());
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/error-tracking.js
+++ b/javascripts/govuk/analytics/error-tracking.js
@@ -1,6 +1,9 @@
 // Extension to track errors using google analytics as a data store.
-(function() {
+(function(global) {
   "use strict";
+
+  var GOVUK = global.GOVUK || {};
+
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
 
   GOVUK.analyticsPlugins.error = function (options) {
@@ -35,12 +38,14 @@
       return false;
     }
 
-    if (window.addEventListener) {
-      window.addEventListener('error', trackJavaScriptError, false);
-    } else if (window.attachEvent) {
-      window.attachEvent('onerror', trackJavaScriptError);
+    if (global.addEventListener) {
+      global.addEventListener('error', trackJavaScriptError, false);
+    } else if (global.attachEvent) {
+      global.attachEvent('onerror', trackJavaScriptError);
     } else {
-      window.onerror = trackJavaScriptError;
+      global.onerror = trackJavaScriptError;
     }
   }
-}());
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/external-link-tracker.js
+++ b/javascripts/govuk/analytics/external-link-tracker.js
@@ -1,5 +1,8 @@
-(function() {
+(function(global) {
   "use strict";
+
+  var GOVUK = global.GOVUK || {};
+
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
   GOVUK.analyticsPlugins.externalLinkTracker = function () {
 
@@ -33,6 +36,8 @@
   }
 
   GOVUK.analyticsPlugins.externalLinkTracker.getHostname = function() {
-    return window.location.hostname;
+    return global.location.hostname;
   }
-}());
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -1,6 +1,7 @@
-(function() {
+(function(global) {
   "use strict";
-  window.GOVUK = window.GOVUK || {};
+
+  var GOVUK = global.GOVUK || {};
 
   var GoogleAnalyticsUniversalTracker = function(id, cookieDomain) {
     configureProfile(id, cookieDomain);
@@ -20,7 +21,7 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(global,document,'script','//www.google-analytics.com/analytics.js','ga');
   };
 
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
@@ -140,10 +141,12 @@
   };
 
   function sendToGa() {
-    if (typeof window.ga === "function") {
-      ga.apply(window, arguments);
+    if (typeof global.ga === "function") {
+      ga.apply(global, arguments);
     }
   }
 
   GOVUK.GoogleAnalyticsUniversalTracker = GoogleAnalyticsUniversalTracker;
-})();
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/mailto-link-tracker.js
+++ b/javascripts/govuk/analytics/mailto-link-tracker.js
@@ -1,5 +1,8 @@
-(function() {
+(function(global) {
   "use strict";
+
+  var GOVUK = global.GOVUK || {};
+
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
   GOVUK.analyticsPlugins.mailtoLinkTracker = function () {
 
@@ -30,4 +33,6 @@
       return $target;
     }
   }
-}());
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/analytics/print-intent.js
+++ b/javascripts/govuk/analytics/print-intent.js
@@ -1,6 +1,8 @@
 // Extension to monitor attempts to print pages.
-(function () {
+(function (global) {
   "use strict";
+
+  var GOVUK = global.GOVUK || {};
 
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {};
 
@@ -11,15 +13,15 @@
     });
 
     // Most browsers
-    if (window.matchMedia) {
-      var mediaQueryList = window.matchMedia('print'),
+    if (global.matchMedia) {
+      var mediaQueryList = global.matchMedia('print'),
         mqlListenerCount = 0;
       mediaQueryList.addListener(function (mql) {
         if (!mql.matches && mqlListenerCount === 0) {
           printAttempt();
           mqlListenerCount++;
           // If we try and print again within 3 seconds, don't log it
-          window.setTimeout(function () {
+          setTimeout(function () {
             mqlListenerCount = 0;
             // printing will be tracked again now
           }, 3000);
@@ -28,10 +30,11 @@
     }
 
     // IE < 10
-    if (window.onafterprint) {
-      window.onafterprint = printAttempt;
+    if (global.onafterprint) {
+      global.onafterprint = printAttempt;
     }
 
   };
 
-}());
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/modules.js
+++ b/javascripts/govuk/modules.js
@@ -1,6 +1,8 @@
-(function($, root) {
+(function(global) {
   "use strict";
-  root.GOVUK = root.GOVUK || {};
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
   GOVUK.Modules = GOVUK.Modules || {};
 
   GOVUK.modules = {
@@ -53,4 +55,6 @@
       }
     }
   }
-})(jQuery, window);
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/modules/auto-track-event.js
+++ b/javascripts/govuk/modules/auto-track-event.js
@@ -1,7 +1,10 @@
-(function(Modules) {
+(function(global) {
   "use strict";
 
-  Modules.AutoTrackEvent = function() {
+  var GOVUK = global.GOVUK || {};
+  GOVUK.Modules = GOVUK.Modules || {};
+
+  GOVUK.Modules.AutoTrackEvent = function() {
     this.start = function(element) {
       var options = {nonInteraction: 1}, // automatic events shouldn't affect bounce rate
           category = element.data('track-category'),
@@ -23,4 +26,5 @@
     }
   };
 
-})(window.GOVUK.Modules);
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -1,7 +1,8 @@
-(function() {
+(function(global) {
   "use strict";
-  window.GOVUK = window.GOVUK || {};
-  var $ = window.$;
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   // A multivariate test framework
   //
@@ -130,5 +131,7 @@
     return "multivariatetest_cohort_" + this.name;
   };
 
-  window.GOVUK.MultivariateTest = MultivariateTest;
-}());
+  GOVUK.MultivariateTest = MultivariateTest;
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/primary-links.js
+++ b/javascripts/govuk/primary-links.js
@@ -1,6 +1,8 @@
-(function() {
+(function(global) {
   "use strict";
-  window.GOVUK = window.GOVUK || {};
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   // Only show the first {n} items in a list, documentation is in the README.md
   var PrimaryList = function(el, selector){
@@ -39,6 +41,7 @@
       $(window).trigger('govuk.pageSizeChanged');
     }
   };
+
   GOVUK.PrimaryList = PrimaryList;
 
   GOVUK.primaryLinks = {
@@ -48,4 +51,6 @@
       });
     }
   };
-}());
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -1,9 +1,8 @@
-(function () {
+(function (global) {
   "use strict";
-  var root = this,
-      $ = root.jQuery;
 
-  if (typeof GOVUK === 'undefined') { root.GOVUK = {}; }
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   var SelectionButtons = function (elmsOrSelector, opts) {
     var $elms;
@@ -107,5 +106,6 @@
     }
   };
 
-  root.GOVUK.SelectionButtons = SelectionButtons;
-}).call(this);
+  GOVUK.SelectionButtons = SelectionButtons;
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/stick-at-top-when-scrolling.js
+++ b/javascripts/govuk/stick-at-top-when-scrolling.js
@@ -1,8 +1,8 @@
-(function () {
+(function (global) {
   "use strict";
-  var root = this,
-      $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   // Stick elements to top of screen when you scroll past, documentation is in the README.md
   var sticky = {
@@ -16,22 +16,22 @@
         sticky.$els = $els;
 
         if(sticky._scrollTimeout === false) {
-          $(root).scroll(sticky.onScroll);
-          sticky._scrollTimeout = root.setInterval(sticky.checkScroll, 50);
+          $(global).scroll(sticky.onScroll);
+          sticky._scrollTimeout = global.setInterval(sticky.checkScroll, 50);
         }
-        $(root).resize(sticky.onResize);
+        $(global).resize(sticky.onResize);
       }
-      if(root.GOVUK.stopScrollingAtFooter){
+      if(GOVUK.stopScrollingAtFooter){
         $els.each(function(i,el){
           var $img = $(el).find('img');
           if($img.length > 0){
             var image = new Image();
             image.onload = function(){
-              root.GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
+              GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
             };
             image.src = $img.attr('src');
           } else {
-            root.GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
+            GOVUK.stopScrollingAtFooter.addEl($(el), $(el).outerHeight());
           }
         });
       }
@@ -43,14 +43,14 @@
       if(sticky._hasScrolled === true){
         sticky._hasScrolled = false;
 
-        var windowVerticalPosition = $(root).scrollTop();
+        var windowVerticalPosition = $(global).scrollTop();
         sticky.$els.each(function(i, el){
           var $el = $(el),
               scrolledFrom = $el.data('scrolled-from');
 
           if (scrolledFrom && windowVerticalPosition < scrolledFrom){
             sticky.release($el);
-          } else if($(root).width() > 768 && windowVerticalPosition >= $el.offset().top) {
+          } else if($(global).width() > 768 && windowVerticalPosition >= $el.offset().top) {
             sticky.stick($el);
           }
         });
@@ -72,5 +72,6 @@
       }
     }
   };
-  root.GOVUK.stickAtTopWhenScrolling = sticky;
-}).call(this);
+  GOVUK.stickAtTopWhenScrolling = sticky;
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/javascripts/govuk/stop-scrolling-at-footer.js
@@ -11,11 +11,11 @@
 // itself.
 
 
-(function () {
+(function (global) {
   "use strict";
-  var root = this,
-      $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
   var stopScrollingAtFooter = {
     _pollingId: null,
@@ -32,7 +32,7 @@
       fixedOffset = isNaN(fixedOffset) ? 0 : fixedOffset;
 
       stopScrollingAtFooter.updateFooterTop();
-      $(root).on('govuk.pageSizeChanged', stopScrollingAtFooter.updateFooterTop);
+      $(global).on('govuk.pageSizeChanged', stopScrollingAtFooter.updateFooterTop);
 
       var $siblingEl = $('<div></div>');
       $siblingEl.insertBefore($fixedEl);
@@ -63,7 +63,7 @@
       }
     },
     onScroll: function(){
-      if (stopScrollingAtFooter._isPolling === false) { 
+      if (stopScrollingAtFooter._isPolling === false) {
         stopScrollingAtFooter.startPolling();
       }
     },
@@ -132,7 +132,9 @@
     }
   };
 
-  root.GOVUK.stopScrollingAtFooter = stopScrollingAtFooter;
+  GOVUK.stopScrollingAtFooter = stopScrollingAtFooter;
 
-  $(root).load(function(){ $(root).trigger('govuk.pageSizeChanged'); });
-}).call(this);
+  $(global).load(function(){ $(global).trigger('govuk.pageSizeChanged'); });
+
+  global.GOVUK = GOVUK;
+})(window);

--- a/javascripts/stageprompt.js
+++ b/javascripts/stageprompt.js
@@ -1,63 +1,70 @@
 // Stageprompt 2.0.1
-// 
+//
 // See: https://github.com/alphagov/stageprompt
-// 
-// Stageprompt allows user journeys to be described and instrumented 
+//
+// Stageprompt allows user journeys to be described and instrumented
 // using data attributes.
-// 
+//
 // Setup (run this on document ready):
-// 
+//
 //   GOVUK.performance.stageprompt.setupForGoogleAnalytics();
-// 
+//
 // Usage:
-// 
+//
 //   Sending events on page load:
-// 
+//
 //     <div id="wrapper" class="service" data-journey="pay-register-birth-abroad:start">
 //         [...]
 //     </div>
-//     
+//
 //   Sending events on click:
-//   
+//
 //     <a class="help-button" href="#" data-journey-click="stage:help:info">See more info...</a>
 
-var GOVUK = GOVUK || {};
+(function(global) {
+  "use strict";
 
-GOVUK.performance = GOVUK.performance || {};
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
 
-GOVUK.performance.stageprompt = (function () {
+  GOVUK.performance = GOVUK.performance || {};
 
-  var setup, setupForGoogleAnalytics, splitAction;
+  GOVUK.performance.stageprompt = (function () {
 
-  splitAction = function (action) {
-    var parts = action.split(':');
-    if (parts.length <= 3) return parts;
-    return [parts.shift(), parts.shift(), parts.join(':')];
+    var setup, setupForGoogleAnalytics, splitAction;
+
+    splitAction = function (action) {
+      var parts = action.split(':');
+      if (parts.length <= 3) return parts;
+      return [parts.shift(), parts.shift(), parts.join(':')];
+    };
+
+    setup = function (analyticsCallback) {
+      var journeyStage = $('[data-journey]').attr('data-journey'),
+          journeyHelpers = $('[data-journey-click]');
+
+      if (journeyStage) {
+        analyticsCallback.apply(null, splitAction(journeyStage));
+      }
+
+      journeyHelpers.on('click', function (event) {
+        analyticsCallback.apply(null, splitAction($(this).data('journey-click')));
+      });
+    };
+
+    setupForGoogleAnalytics = function () {
+      setup(GOVUK.performance.sendGoogleAnalyticsEvent);
+    };
+
+    return {
+      setup: setup,
+      setupForGoogleAnalytics: setupForGoogleAnalytics
+    };
+  }());
+
+  GOVUK.performance.sendGoogleAnalyticsEvent = function (category, event, label) {
+    _gaq.push(['_trackEvent', category, event, label, undefined, true]);
   };
 
-  setup = function (analyticsCallback) {
-    var journeyStage = $('[data-journey]').attr('data-journey'),
-        journeyHelpers = $('[data-journey-click]');
-
-    if (journeyStage) {
-      analyticsCallback.apply(null, splitAction(journeyStage));
-    }
-    
-    journeyHelpers.on('click', function (event) {
-      analyticsCallback.apply(null, splitAction($(this).data('journey-click')));
-    });
-  };
-  
-  setupForGoogleAnalytics = function () {
-    setup(GOVUK.performance.sendGoogleAnalyticsEvent);
-  };
-
-  return {
-    setup: setup,
-    setupForGoogleAnalytics: setupForGoogleAnalytics
-  };
-}());
-
-GOVUK.performance.sendGoogleAnalyticsEvent = function (category, event, label) {
-  _gaq.push(['_trackEvent', category, event, label, undefined, true]);
-};
+  global.GOVUK = GOVUK;
+})(window);

--- a/spec/support/load.js
+++ b/spec/support/load.js
@@ -1,4 +1,4 @@
-(function (root) {
+(function (global) {
   "use strict"
   var loadedScripts = 0,
       totalScripts,
@@ -44,4 +44,4 @@
     totalScripts = merge([manifest.support, manifest.test]);
     loadScript(totalScripts[idx], idx + 1);
   };
-}).call(this);
+})(window);


### PR DESCRIPTION
Hi,

So I can avoid multiple `<script>` includes, I'm adding base modules via Browserify (same principle for Webpack, Rollup etc) using this sort of syntax:

```
require('govuk/selection-buttons');
require('govuk/analytics/analytics');
```

Problem is, I've noticed a lot of the modules use `this` but that wrongly assumes `this == window`.

To resolve, this fork ensures all base modules attach to the `window` global for compatibility. I've also noticed use of `root` internally so I've further rolled this out to all modules for consistency.

These changes make no assumption that the `GOVUK` global variable exists. Some modules tested for this, some didn’t. Checks for this have now been tidied up.

This is a stepping-stone to a nice dependency-injected asynchonrous module future, without adding/removing properties on the `window.GOVUK` global.

Hope this helps.