### PR TITLE
Configurable duration (in days) for AB Test cookie.

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -178,6 +178,20 @@ var test = new GOVUK.MultivariateTest({
 });
 ```
 
+If you want to set the cookie expiration then you can optionally set cookieDuration as follows:
+
+```javascript
+var test = new GOVUK.MultivariateTest({
+  name: 'car_tax_button_text',
+  cookieDuration: 14,
+  cohorts: {
+    pay_your_car_tax: {weight: 25, callback: function() { ... }}, // 25%
+    give_us_money:    {weight: 75, callback: function() { ... }}  // 75%
+  }
+});
+```
+Here, it is set to expire in 14 days time. if this option is not set the default cookie expiration (30 days) take effect.
+
 If you have a complex test, it may be worth extending MultivariateTest with
 your own. Callbacks can be strings which will call a method of that name
 on the current object.

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -18,6 +18,7 @@
     this._loadOption(options, 'runImmediately', true);
     this._loadOption(options, 'defaultWeight', 1);
     this._loadOption(options, 'contentExperimentId', null);
+    this._loadOption(options, 'cookieDuration', 30);
 
     if (this.runImmediately) {
       this.run();
@@ -69,7 +70,7 @@
     var cohort = GOVUK.cookie(this.cookieName());
     if (!cohort || !this.cohorts[cohort]) {
       cohort = this.chooseRandomCohort();
-      GOVUK.cookie(this.cookieName(), cohort, {days: 30});
+      GOVUK.cookie(this.cookieName(), cohort, {days: this.cookieDuration});
     }
     return cohort;
   };

--- a/spec/unit/multivariate-test.spec.js
+++ b/spec/unit/multivariate-test.spec.js
@@ -124,6 +124,29 @@ describe("MultivariateTest", function() {
       expect(test.fooCallback).toHaveBeenCalled();
     });
 
+    it("should assign 30 if cookieDuration isn't defined", function() {
+      GOVUK.cookie.and.returnValue('foo');
+      var test = new GOVUK.MultivariateTest({
+        name: 'cookie_duration_test',
+        cohorts: {
+          foo: {callback: function(){}}
+        }
+      });
+      expect(test.cookieDuration).toEqual(30);
+    });
+
+    it("should assign the user's cookie duration, when cookieDuration is defined", function() {
+      GOVUK.cookie.and.returnValue('foo');
+      var test = new GOVUK.MultivariateTest({
+        name: 'cookie_duration_test',
+        cookieDuration: 14,
+        cohorts: {
+          foo: {callback: function(){}}
+        }
+      });
+      expect(test.cookieDuration).toEqual(14);
+    });
+
     it("should assign a new random cohort if the assigned cohort does not exist", function() {
       var fooSpy = jasmine.createSpy('fooSpy');
       var barSpy = jasmine.createSpy('barSpy');


### PR DESCRIPTION
Here, I have added a new option (cookieDuration), this option help to set the cookie expiration duration in days.

When this option isn't supplied the the default cookie duration is set to expire in 30 days.

## Motivation 

The motivation here is, by reducing the cookie expiration will allow returning users to be assigned
to different cohorts during A/B tests.

According to the performance analyst, A/B tests performance is measured using sessions and with
a default 30 day expiration, they will only see the one variant for that period.  Being able to 
reduce this increases the likelihood of users seeing different variants across their sessions.

### Sample code
```javascript
  new GOVUK.MultivariateTest({
      el: '.get-started a',
      name: 'startButton_201607',
      customDimensionIndex: <customDimensionIndex>,
      cookieDuration: 14, // set to 14 days
      contentExperimentId: <contentExperimentId>,
      cohorts: {
        original: { callback: function() {}, variantId: 0},
        next: { html: 'Next', variantId: 1 },
        continue: { html: 'Continue', variantId: 2 }
      }
    });
```
### Sample outcome
![screen shot 2016-07-13 at 15 33 38](https://cloud.githubusercontent.com/assets/84896/16807129/3516d15c-490f-11e6-8a30-7f00e66fbc04.png)
