### PR TITLE
Allow use of multiple `customDimensionIndex` option

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -264,6 +264,24 @@ var test = new GOVUK.MultivariateTest({
 
 `customDimensionIndex` is the index of the custom variable in Google Analytics. GA only gives 50 integer slots to each account, and it is important that a unique integer is assigned to each test. Current contact for assigning a custom var slot for GOV.UK is: Tim Leighton-Boyce <tim.leighton-boyce@digital.cabinet-office.gov.uk>
 
+For certain types of tests where the custom dimensions in Google Analytics can only have one of three scopes (hit, session, or user). Measuring performance of A/B tests, and want to compare test results for session-scoped custom dimensions (eg: index 222) against hit-scoped ones (eg: index 223) may become important.
+
+Instead of supplying an integer (like the above example), `customDimensionIndex` can also accept an array of dimension indexes ([222, 223]), see below for more.
+
+Make sure to check GA debugger that these values are being sent before deploying.
+
+```js
+var test = new GOVUK.MultivariateTest({
+  name: 'car_tax_button_text',
+  customDimensionIndex: [222, 223],
+  cohorts: {
+    pay_your_car_tax: {weight: 25},
+    give_us_money: {weight: 50}
+  }
+});
+```
+
+
 ## Primary Links
 
 `GOVUK.PrimaryList` hides elements in a list which don't have a supplied

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -76,12 +76,21 @@
   };
 
   MultivariateTest.prototype.setCustomVar = function(cohort) {
-    if (this.customDimensionIndex) {
-      GOVUK.analytics.setDimension(
-        this.customDimensionIndex,
-        this.cookieName() + "__" + cohort
-      );
+    if (this.customDimensionIndex &&
+      this.customDimensionIndex.constructor === Array) {
+      for (var index = 0; index < this.customDimensionIndex.length; index++) {
+        this.setDimension(cohort, this.customDimensionIndex[index])
+      }
+    } else if (this.customDimensionIndex) {
+      this.setDimension(cohort, this.customDimensionIndex)
     }
+  };
+
+  MultivariateTest.prototype.setDimension = function(cohort, dimension) {
+    GOVUK.analytics.setDimension(
+      dimension,
+      this.cookieName() + "__" + cohort
+    );
   };
 
   MultivariateTest.prototype.setUpContentExperiment = function(cohort) {

--- a/spec/unit/multivariate-test.spec.js
+++ b/spec/unit/multivariate-test.spec.js
@@ -63,6 +63,26 @@ describe("MultivariateTest", function() {
       );
     });
 
+    it("should be able to set multiple custom vars with the name and cohort if one is defined as an array", function() {
+      GOVUK.cookie.and.returnValue('foo');
+      var test = new GOVUK.MultivariateTest({
+        name: 'stuff',
+        cohorts: {
+          foo: {},
+          bar: {}
+        },
+        customDimensionIndex: [2,3]
+      });
+      expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(
+        2,
+        'multivariatetest_cohort_stuff__foo'
+      );
+      expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(
+        3,
+        'multivariatetest_cohort_stuff__foo'
+      );
+    });
+
     it("should trigger an event to track that the test has been run", function() {
       GOVUK.cookie.and.returnValue('foo');
       var test = new GOVUK.MultivariateTest({


### PR DESCRIPTION
## Description 
In this commit I have added code to allow more that one `customDimensionIndex` to be used during AB test.

Custom dimensions in Google Analytics can only have one of three scopes (hit, session, or user).
We need to explore how we measure the performance of A/B tests, and want to compare test results for
session-scoped custom dimensions (eg: index 222) against hit-scoped ones (eg: index 223).

## Sample code

```js

//= require govuk/multivariate-test

$(function(){
  if(isExpectedPath("overseas-passports")) {
    new GOVUK.MultivariateTest({
      el: '.get-started a',
      name: 'startButton_201607',
      customDimensionIndex: 13,
      contentExperimentId: '<customDimensionIndex>',
      cohorts: {
        original: { callback: function() {}, variantId: 0 },
        getApplicationInfo: { html: 'Get application information', variantId: 1 },
        next: { html: 'Next', variantId: 2 }
      }
    });
  }

  if(isExpectedPath("calculate-your-child-maintenance")) {
    new GOVUK.MultivariateTest({
      el: '.get-started a',
      name: 'startButton_201607',
      customDimensionIndex: [13, 14],
      contentExperimentId: '<customDimensionIndex>',
      cohorts: {
        original: { callback: function() {}, variantId: 0 },
        calculate: { html: 'Calculate', variantId: 1 },
        estimateChildMaintenance: { html: 'Estimate your child maintenance', variantId: 2 }
      }
    });
  }

  if(isExpectedPath("marriage-abroad")) {
    new GOVUK.MultivariateTest({
      el: '.get-started a',
      name: 'startButton_201607',
      customDimensionIndex: 14,
      contentExperimentId: '<customDimensionIndex>',
      cohorts: {
        original: { callback: function() {}, variantId: 0},
        next: { html: 'Next', variantId: 1 },
        continue: { html: 'Continue', variantId: 2 }
      }
    });
  }

  function isExpectedPath(slug) {
    var currentPath = window.location.pathname.split("/").join("");
    return currentPath == slug
  }
});

```


### Outcome with Marriage abroad

#### Expected result

* customDimensionIndex is set to 14 only

![screen shot 2016-07-13 at 16 14 07](https://cloud.githubusercontent.com/assets/84896/16810476/e62db68e-491b-11e6-9901-b95e5bd5dfe4.png)


### Outcome with Child maintenance calculator

#### Expected result

* customDimensionIndex is set to 13 and 14 (hit and session)

![screen shot 2016-07-13 at 16 15 07](https://cloud.githubusercontent.com/assets/84896/16810487/ed44b526-491b-11e6-9322-205b96426a83.png)
