### PR TITLE
Add support for Google Analytics fieldsObject on create

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -34,8 +34,7 @@ The minimum you need to use the analytics function is:
 
   // Configure profiles and make interface public
   // for custom dimensions, virtual pageviews and events
-  GOVUK.analytics = new GOVUK.Analytics({
-    universalId: 'UA-XXXXXXXX-X',
+  GOVUK.analytics = new GOVUK.Analytics('UA-XXXXXXXX-X', {
     cookieDomain: cookieDomain
   });
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -34,7 +34,8 @@ The minimum you need to use the analytics function is:
 
   // Configure profiles and make interface public
   // for custom dimensions, virtual pageviews and events
-  GOVUK.analytics = new GOVUK.Analytics('UA-XXXXXXXX-X', {
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-XXXXXXXX-X',
     cookieDomain: cookieDomain
   });
 

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -6,10 +6,24 @@
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
-  var Analytics = function(config) {
+  var Analytics = function(trackingId, fieldsObject) {
     this.trackers = [];
-    if (typeof config.universalId != 'undefined') {
-      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain, config.fieldsObject));
+    fieldsObject = fieldsObject || {};
+
+    // Support legacy config syntax
+    if (typeof trackingId === 'object') {
+
+      if (trackingId.cookieDomain) {
+        fieldsObject.cookieDomain = trackingId.cookieDomain;
+      }
+
+      if (trackingId.universalId) {
+        trackingId = trackingId.universalId;
+      }
+    }
+
+    if (trackingId) {
+      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(trackingId, fieldsObject));
     }
   };
 

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -6,10 +6,10 @@
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
-  var Analytics = function(config, fieldsObject) {
+  var Analytics = function(config) {
     this.trackers = [];
     if (typeof config.universalId != 'undefined') {
-      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain, fieldsObject));
+      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain, config.fieldsObject));
     }
   };
 

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -6,24 +6,12 @@
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
-  var Analytics = function(trackingId, fieldsObject) {
+  var Analytics = function(config) {
     this.trackers = [];
-    fieldsObject = fieldsObject || {};
-
-    // Support legacy config syntax
-    if (typeof trackingId === 'object') {
-
-      if (trackingId.cookieDomain) {
-        fieldsObject.cookieDomain = trackingId.cookieDomain;
-      }
-
-      if (trackingId.universalId) {
-        trackingId = trackingId.universalId;
-      }
-    }
-
-    if (trackingId) {
-      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(trackingId, fieldsObject));
+    if (typeof config.universalId != 'undefined') {
+      var universalId = config.universalId;
+      delete config.universalId;
+      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(universalId, config));
     }
   };
 

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -6,10 +6,10 @@
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
-  var Analytics = function(config) {
+  var Analytics = function(config, fieldsObject) {
     this.trackers = [];
     if (typeof config.universalId != 'undefined') {
-      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain));
+      this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(config.universalId, config.cookieDomain, fieldsObject));
     }
   };
 

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -3,9 +3,9 @@
 
   var GOVUK = global.GOVUK || {};
 
-  var GoogleAnalyticsUniversalTracker = function(trackingId, cookieDomain, fieldsObject) {
+  var GoogleAnalyticsUniversalTracker = function(trackingId, fieldsObject) {
 
-    function configureProfile(trackingId, fieldsObject) {
+    function configureProfile() {
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
       sendToGa('create', trackingId, fieldsObject);
     }
@@ -15,11 +15,12 @@
       sendToGa('set', 'anonymizeIp', true);
     }
 
-    // Append cookieDomain to fieldsObject
-    fieldsObject = fieldsObject || {}
-    fieldsObject.cookieDomain = cookieDomain;
+    // Support legacy cookieDomain param
+    if (typeof fieldsObject === 'string') {
+      fieldsObject = { cookieDomain: fieldsObject };
+    }
 
-    configureProfile(trackingId, fieldsObject);
+    configureProfile();
     anonymizeIp();
   };
 

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -27,7 +27,7 @@
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                              m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(global,document,'script','//www.google-analytics.com/analytics.js','ga');
+    })(global,document,'script','https://www.google-analytics.com/analytics.js','ga');
   };
 
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -3,18 +3,24 @@
 
   var GOVUK = global.GOVUK || {};
 
-  var GoogleAnalyticsUniversalTracker = function(id, cookieDomain) {
-    configureProfile(id, cookieDomain);
-    anonymizeIp();
+  var GoogleAnalyticsUniversalTracker = function(trackingId, cookieDomain, fieldsObject) {
 
-    function configureProfile(id, cookieDomain) {
-      sendToGa('create', id, {'cookieDomain': cookieDomain});
+    function configureProfile(trackingId, fieldsObject) {
+      https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
+      sendToGa('create', trackingId, fieldsObject);
     }
 
     function anonymizeIp() {
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/advanced#anonymizeip
       sendToGa('set', 'anonymizeIp', true);
     }
+
+    // Append cookieDomain to fieldsObject
+    fieldsObject = fieldsObject || {}
+    fieldsObject.cookieDomain = cookieDomain;
+
+    configureProfile(trackingId, fieldsObject);
+    anonymizeIp();
   };
 
   GoogleAnalyticsUniversalTracker.load = function() {

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -6,7 +6,7 @@
   var GoogleAnalyticsUniversalTracker = function(trackingId, cookieDomain, fieldsObject) {
 
     function configureProfile(trackingId, fieldsObject) {
-      https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
+      // https://developers.google.com/analytics/devguides/collection/analyticsjs/command-queue-reference#create
       sendToGa('create', trackingId, fieldsObject);
     }
 

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -10,8 +10,8 @@ describe("GOVUK.Analytics", function() {
   beforeEach(function() {
     addGoogleAnalyticsSpy();
 
-    // New syntax keeps trackingId separate from fieldsObject
-    analytics = new GOVUK.Analytics('universal-id', {
+    analytics = new GOVUK.Analytics({
+      universalId: 'universal-id',
       cookieDomain: '.www.gov.uk',
       siteSpeedSampleRate: 100
     });
@@ -24,24 +24,6 @@ describe("GOVUK.Analytics", function() {
 
     it('configures a universal tracker', function () {
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk', siteSpeedSampleRate: 100}]);
-    });
-  });
-
-  describe('when created (with legacy mixed-object syntax)', function() {
-    beforeEach(function() {
-      addGoogleAnalyticsSpy();
-
-      // Legacy syntax mixes a non-standard `universalId` into the fieldsObject
-      analytics = new GOVUK.Analytics({
-        universalId: 'universal-id',
-        cookieDomain: '.www.gov.uk',
-      });
-
-      universalSetupArguments = window.ga.calls.allArgs();
-    });
-
-    it('configures a Google tracker using the provided profile ID and cookie domain', function() {
-      expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk'}]);
     });
   });
 

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -6,13 +6,13 @@ describe("GOVUK.Analytics", function() {
     spyOn(window, 'ga');
     this.config = {
       universalId: 'universal-id',
-      cookieDomain: '.www.gov.uk'
+      cookieDomain: '.www.gov.uk',
+      fieldsObject = {
+        siteSpeedSampleRate: 100
+      }
     };
-    this.fieldsObject = {
-      siteSpeedSampleRate: 100
-    }
 
-    analytics = new GOVUK.Analytics(this.config, this.fieldsObject);
+    analytics = new GOVUK.Analytics(this.config);
   });
 
   describe('when created', function() {

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -8,14 +8,17 @@ describe("GOVUK.Analytics", function() {
       universalId: 'universal-id',
       cookieDomain: '.www.gov.uk'
     };
+    this.fieldsObject = {
+      siteSpeedSampleRate: 100
+    }
 
-    analytics = new GOVUK.Analytics(this.config);
+    analytics = new GOVUK.Analytics(this.config, this.fieldsObject);
   });
 
   describe('when created', function() {
     it('configures a universal tracker', function () {
       var universalSetupArguments = window.ga.calls.allArgs();
-      expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {'cookieDomain': '.www.gov.uk'}]);
+      expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk', siteSpeedSampleRate: 100}]);
     });
   });
 

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -1,24 +1,47 @@
 describe("GOVUK.Analytics", function() {
-  var analytics;
-
-  beforeEach(function() {
+  function addGoogleAnalyticsSpy() {
     window.ga = function() {};
     spyOn(window, 'ga');
-    this.config = {
-      universalId: 'universal-id',
-      cookieDomain: '.www.gov.uk',
-      fieldsObject = {
-        siteSpeedSampleRate: 100
-      }
-    };
+  }
 
-    analytics = new GOVUK.Analytics(this.config);
+  var analytics;
+  var universalSetupArguments;
+
+  beforeEach(function() {
+    addGoogleAnalyticsSpy();
+
+    // New syntax keeps trackingId separate from fieldsObject
+    analytics = new GOVUK.Analytics('universal-id', {
+      cookieDomain: '.www.gov.uk',
+      siteSpeedSampleRate: 100
+    });
   });
 
   describe('when created', function() {
+    beforeEach(function() {
+      universalSetupArguments = window.ga.calls.allArgs();
+    });
+
     it('configures a universal tracker', function () {
-      var universalSetupArguments = window.ga.calls.allArgs();
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk', siteSpeedSampleRate: 100}]);
+    });
+  });
+
+  describe('when created (with legacy mixed-object syntax)', function() {
+    beforeEach(function() {
+      addGoogleAnalyticsSpy();
+
+      // Legacy syntax mixes a non-standard `universalId` into the fieldsObject
+      analytics = new GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: '.www.gov.uk',
+      });
+
+      universalSetupArguments = window.ga.calls.allArgs();
+    });
+
+    it('configures a Google tracker using the provided profile ID and cookie domain', function() {
+      expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk'}]);
     });
   });
 

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -1,10 +1,19 @@
 describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
-  var universal;
-
-  beforeEach(function() {
+  function addGoogleAnalyticsSpy() {
     window.ga = function() {};
     spyOn(window, 'ga');
-    universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', 'cookie-domain.com', { siteSpeedSampleRate: 100 });
+  }
+
+  var universal;
+  var setupArguments;
+
+  beforeEach(function() {
+    addGoogleAnalyticsSpy();
+
+    universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', {
+      cookieDomain: 'cookie-domain.com',
+      siteSpeedSampleRate: 100
+    });
   });
 
   it('can load the libraries needed to run universal Google Analytics', function() {
@@ -19,18 +28,29 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
   });
 
   describe('when created', function() {
-    var setupArguments;
-
     beforeEach(function() {
       setupArguments = window.ga.calls.allArgs();
     });
 
-    it('configures a Google tracker using the provided profile ID and cookie domain', function() {
+    it('configures a Google tracker using the provided profile ID and config', function() {
       expect(setupArguments[0]).toEqual(['create', 'id', {cookieDomain: 'cookie-domain.com', siteSpeedSampleRate: 100}]);
     });
 
     it('anonymises the IP', function() {
       expect(setupArguments[1]).toEqual(['set', 'anonymizeIp', true]);
+    });
+  });
+
+  describe('when created (with legacy non-object syntax)', function() {
+    beforeEach(function() {
+      addGoogleAnalyticsSpy();
+
+      universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', 'cookie-domain.com');
+      setupArguments = window.ga.calls.allArgs();
+    });
+
+    it('configures a Google tracker using the provided profile ID and cookie domain', function() {
+      expect(setupArguments[0]).toEqual(['create', 'id', {cookieDomain: 'cookie-domain.com'}]);
     });
   });
 

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -9,9 +9,9 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
 
   it('can load the libraries needed to run universal Google Analytics', function() {
     delete window.ga;
-    $('[src="//www.google-analytics.com/analytics.js"]').remove();
+    $('[src="https://www.google-analytics.com/analytics.js"]').remove();
     GOVUK.GoogleAnalyticsUniversalTracker.load();
-    expect($('script[async][src="//www.google-analytics.com/analytics.js"]').length).toBe(1);
+    expect($('script[async][src="https://www.google-analytics.com/analytics.js"]').length).toBe(1);
     expect(typeof window.ga).toBe('function');
 
     window.ga('send message');

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -4,7 +4,7 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
   beforeEach(function() {
     window.ga = function() {};
     spyOn(window, 'ga');
-    universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', 'cookie-domain.com');
+    universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', 'cookie-domain.com', { siteSpeedSampleRate: 100 });
   });
 
   it('can load the libraries needed to run universal Google Analytics', function() {
@@ -26,7 +26,7 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
     });
 
     it('configures a Google tracker using the provided profile ID and cookie domain', function() {
-      expect(setupArguments[0]).toEqual(['create', 'id', {'cookieDomain': 'cookie-domain.com'}]);
+      expect(setupArguments[0]).toEqual(['create', 'id', {cookieDomain: 'cookie-domain.com', siteSpeedSampleRate: 100}]);
     });
 
     it('anonymises the IP', function() {


### PR DESCRIPTION
Like the `cookieDomain` field, other fields are “Create Only”:

1. `sampleRate`
2. `siteSpeedSampleRate`
3. `allowLinker`

See the reference guide here:
https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference

Currently `cookieDomain` is hard-coded into the GA `create` call:
https://github.com/alphagov/govuk_frontend_toolkit/commit/ee2fd0de3e11855ed6828a728a2854a902b28274#diff-8b93af583c1a7ca5e9c48a89ebce2b38R10

This means none of the fields above can be added 😢 

### Extensibility
To expand on this, I've added a new `fieldsObject` parameter to these methods:
```js
new GOVUK.Analytics(config, fieldsObject)
new GOVUK.GoogleAnalyticsUniversalTracker(id, cookieDomain, fieldsObject);
```

This change now allows the GOV.UK analytics modules to call:
```js
ga('create', 'id', {
  cookieDomain: 'example.com',

  // New fields now supported
  siteSpeedSampleRate: 100,
  allowAnchor: true
});
```

Thanks