### PR TITLE
[Do not merge] Update the UK Trade Investment organisation color to reflect new brand

### DIFF
--- a/stylesheets/colours/_organisation.scss
+++ b/stylesheets/colours/_organisation.scss
@@ -54,7 +54,7 @@ $the-office-of-the-leader-of-the-house-of-commons: #317023;
 $the-office-of-the-leader-of-the-house-of-commons-websafe: #005f8f;
 $uk-export-finance: #005747;
 $uk-export-finance-websafe: $link-colour;
-$uk-trade-investment: #C80651;
+$uk-trade-investment: #CF102D;
 $uk-trade-investment-websafe: $link-colour;
 $wales-office: #a33038;
 $wales-office-websafe: #7a242a;


### PR DESCRIPTION
As part of https://govuk.zendesk.com/agent/tickets/1385632

In terms of accessibility, the new colour is a darker pink/red so contrast should be better where it's used but I'm not so sure of the reaching changes of this so would appreciate that context :)

![image](https://cloud.githubusercontent.com/assets/2445413/17249452/f41ea52c-5597-11e6-8c77-c7c383c4a219.png)
