### PR TITLE
Move the font-size-adjust properties

### DIFF
--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -27,19 +27,18 @@ $is-print: false !default;
     font-family: $Print-reset;
   } @else {
     font-family: $toolkit-font-stack;
+    @if $toolkit-font-stack == $NTA-Light {
+      @if $font-weight > 400 {
+        font-size-adjust: 0.525;
+      } @else {
+        font-size-adjust: 0.5;
+      }
+    }
   }
   font-size: $font-size-640;
   line-height: $line-height-640;
   font-weight: $font-weight;
   text-transform: none;
-
-  @if $toolkit-font-stack == $NTA-Light {
-    @if $font-weight > 400 {
-      font-size-adjust: 0.525;
-    } @else {
-      font-size-adjust: 0.5;
-    }
-  }
 
   @include media(tablet) {
     font-size: $font-size;

--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -27,7 +27,7 @@ $is-print: false !default;
     font-family: $Print-reset;
   } @else {
     font-family: $toolkit-font-stack;
-    @if $toolkit-font-stack == $NTA-Light {
+    @if $toolkit-font-stack == "$NTA-Light" {
       @if $font-weight > 400 {
         font-size-adjust: 0.525;
       } @else {


### PR DESCRIPTION
We don’t want these to apply to the tabular version of NTA or for print.

Move these properties, so that once the `$toolkit-font-stack` is defined,
we can check to see if the `$toolkit-font-stack` variable matches `"$NTA-Light"`
and if so, apply the font-size-adjust values.

This fixes #300.

cc. @robinwhittleton.