### PR TITLE
Remove unused $elms variable in selection-buttons.js

### DIFF
--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -5,7 +5,6 @@
   var GOVUK = global.GOVUK || {};
 
   var SelectionButtons = function (elmsOrSelector, opts) {
-    var $elms;
 
     this.selectedClass = 'selected';
     this.focusedClass = 'focused';
@@ -15,7 +14,6 @@
       }.bind(this));
     }
     if (typeof elmsOrSelector === 'string') {
-      $elms = $(elmsOrSelector);
       this.selector = elmsOrSelector;
       this.setInitialState($(this.selector));
     } else if (elmsOrSelector !== undefined) {


### PR DESCRIPTION
Previously: https://github.com/alphagov/govuk_frontend_toolkit/pull/295

Turns out the `this.$elms` write isn't necessary since it wasn't being done before anyway. It was being written to `$elms` but not being read from at any later point.

cc @gemmaleigh 