### PR TITLE
Add GOVUK.ShowHideContent JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ In production:
   * [Stick at top when scrolling](/docs/javascript.md#stick-at-top-when-scrolling)
   * [Selection buttons](/docs/javascript.md#selection-buttons)
   * [Shim links with button role](/docs/javascript.md#shim-links-with-button-role)
+  * [Show/Hide content](/docs/javascript.md#show-hide-content)
 * [Analytics](/docs/analytics.md)
   * [Create an analytics tracker](/docs/analytics.md#create-an-analytics-tracker)
   * [Virtual pageviews](/docs/analytics.md#virtual-pageviews)

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -447,24 +447,24 @@ Script to support show/hide content, toggled by radio buttons and checkboxes. Th
       <p>Show/Hide content to be toggled</p>
     </div>
 
-When the input's `checked` attribute is set, the show/hide content's `.js-hidden` class is removed and ARIA attributes are added to enable it.
+When the input's `checked` attribute is set, the show/hide content's `.js-hidden` class is removed and ARIA attributes are added to enable it. Note the sample `show-me` id attribute used to link the label to show/hide content.
 
 ### Usage
 
 #### GOVUK.ShowHideContent
 
-To apply this behaviour to elements with the above HTML pattern, call the `GOVUK.ShowHideContent` constructor with their inputs:
+To apply this behaviour to elements with the above HTML pattern, call the `GOVUK.ShowHideContent` constructor:
 
 ```
 var showHideContent = new GOVUK.ShowHideContent();
 showHideContent.init();
 ```
 
-This will bind all events to the document, meaning any changes to content (for example, by AJAX) will not effect behaviour.
+This will bind two event handlers to $(document.body), one for radio inputs and one for checkboxes. By listening for events bubbling up to the `body` tag, additional show/hide content added to the page will still be picked up after `.init()` is called.
 
-You can also call `GOVUK.ShowHideContent` with a selector (defaults to `$(document.body)`):
+Alternatively, pass in your own selector. In the example below, event handlers are bound to the form instead.
 
 ```
 var showHideContent = new GOVUK.ShowHideContent();
-showHideContent.init($('form'));
+showHideContent.init($('form.example'));
 ```

--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -430,4 +430,41 @@ It’s also possible to define more or different keycodes to activate against:
 GOVUK.shimLinksWithButtonRole.init({
   keycodes: [32, 114]
 });
+
+## Show/Hide content
+
+Script to support show/hide content, toggled by radio buttons and checkboxes. This allows for progressive disclosure of question and answer forms based on selected values:
+
+    <label class="block-label" data-target="show-me">
+      <input type="radio" name="enabled" value="yes" /> Yes
+    </label>
+
+    <label class="block-label">
+      <input type="radio" name="enabled" value="no" /> No
+    </label>
+
+    <div id="show-me" class="panel js-hidden">
+      <p>Show/Hide content to be toggled</p>
+    </div>
+
+When the input's `checked` attribute is set, the show/hide content's `.js-hidden` class is removed and ARIA attributes are added to enable it.
+
+### Usage
+
+#### GOVUK.ShowHideContent
+
+To apply this behaviour to elements with the above HTML pattern, call the `GOVUK.ShowHideContent` constructor with their inputs:
+
+```
+var showHideContent = new GOVUK.ShowHideContent();
+showHideContent.init();
+```
+
+This will bind all events to the document, meaning any changes to content (for example, by AJAX) will not effect behaviour.
+
+You can also call `GOVUK.ShowHideContent` with a selector (defaults to `$(document.body)`):
+
+```
+var showHideContent = new GOVUK.ShowHideContent();
+showHideContent.init($('form'));
 ```

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -48,7 +48,6 @@
 
     // Show toggled content for control
     function showToggledContent ($control, $content) {
-
       // Show content
       if ($content.hasClass('js-hidden')) {
         $content.removeClass('js-hidden')
@@ -80,22 +79,23 @@
     // Handle radio show/hide
     function handleRadioContent ($control, $content) {
 
-      // All radios in this group
-      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + ']'
+      // All radios in this group which control content
+      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + '][aria-controls]'
       var $radios = $control.closest('form').find(selector)
 
-      // Hide radios in group
+      // Hide content for radios in group
       $radios.each(function () {
         hideToggledContent($(this))
       })
 
-      // Select radio button content
-      showToggledContent($control, $content)
+      // Select content for this control
+      if ($control.is('[aria-controls]')) {
+        showToggledContent($control, $content)
+      }
     }
 
     // Handle checkbox show/hide
     function handleCheckboxContent ($control, $content) {
-
       // Show checkbox content
       if ($control.is(':checked')) {
         showToggledContent($control, $content)

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -10,8 +10,8 @@
     // Radio and Checkbox selectors
     var selectors = {
       namespace: 'ShowHideContent',
-      radio: '.block-label input[type="radio"]',
-      checkbox: '.block-label input[type="checkbox"]'
+      radio: '.block-label[data-target] input[type="radio"]',
+      checkbox: '.block-label[data-target] input[type="checkbox"]'
     }
 
     // Escape name attribute for use in DOM selector
@@ -104,7 +104,7 @@
     }
 
     // Set up event handlers etc
-    function init ($container, selector, handler) {
+    function init ($container, elementSelector, eventSelectors, handler) {
       $container = $container || $(document.body)
 
       // Handle control clicks
@@ -114,11 +114,13 @@
       }
 
       // Prepare ARIA attributes
-      var $controls = $(selector)
+      var $controls = $(elementSelector)
       $controls.each(initToggledContent)
 
       // Handle events
-      $container.on('click.' + selectors.namespace, selector, deferred)
+      $.each(eventSelectors, function (idx, eventSelector) {
+        $container.on('click.' + selectors.namespace, eventSelector, deferred)
+      })
 
       // Any already :checked on init?
       if ($controls.is(':checked')) {
@@ -126,14 +128,30 @@
       }
     }
 
+    // Get event selectors for all radio groups
+    function getEventSelectorsForRadioGroups () {
+      var radioGroups = []
+
+      // Build an array of radio group selectors
+      return $(selectors.radio).map(function () {
+        var groupName = $(this).attr('name')
+
+        if ($.inArray(groupName, radioGroups) === -1) {
+          radioGroups.push(groupName)
+          return 'input[type="radio"][name="' + $(this).attr('name') + '"]'
+        }
+        return null
+      })
+    }
+
     // Set up radio show/hide content for container
     self.showHideRadioToggledContent = function ($container) {
-      init($container, selectors.radio, handleRadioContent)
+      init($container, selectors.radio, getEventSelectorsForRadioGroups(), handleRadioContent)
     }
 
     // Set up checkbox show/hide content for container
     self.showHideCheckboxToggledContent = function ($container) {
-      init($container, selectors.checkbox, handleCheckboxContent)
+      init($container, selectors.checkbox, [selectors.checkbox], handleCheckboxContent)
     }
 
     // Remove event handlers

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -1,157 +1,157 @@
-(function (global) {
-  'use strict';
+;(function (global) {
+  'use strict'
 
-  var $ = global.jQuery;
-  var GOVUK = global.GOVUK || {};
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
 
-  function ShowHideContent() {
-    var self = this;
+  function ShowHideContent () {
+    var self = this
 
     // Radio and Checkbox selectors
     var selectors = {
       namespace: 'ShowHideContent',
       radio: '.block-label input[type="radio"]',
       checkbox: '.block-label input[type="checkbox"]'
-    };
+    }
 
     // Escape name attribute for use in DOM selector
-    function escapeElementName(str) {
-      var result = str.replace('[', '\\[').replace(']', '\\]');
-      return(result);
+    function escapeElementName (str) {
+      var result = str.replace('[', '\\[').replace(']', '\\]')
+      return (result)
     }
 
     // Adds ARIA attributes to control + associated content
-    function initToggledContent() {
-      var $control = $(this);
-      var $content = getToggledContent($control);
+    function initToggledContent () {
+      var $control = $(this)
+      var $content = getToggledContent($control)
 
       // Set aria-controls and defaults
       if ($content.length) {
-        $control.attr('aria-controls', $content.attr('id'));
-        $control.attr('aria-expanded', 'false');
-        $content.attr('aria-hidden', 'true');
+        $control.attr('aria-controls', $content.attr('id'))
+        $control.attr('aria-expanded', 'false')
+        $content.attr('aria-hidden', 'true')
       }
     }
 
     // Return toggled content for control
-    function getToggledContent($control) {
-      var id = $control.attr('aria-controls');
+    function getToggledContent ($control) {
+      var id = $control.attr('aria-controls')
 
       // ARIA attributes aren't set before init
       if (!id) {
-        id = $control.parent('label').data('target');
+        id = $control.parent('label').data('target')
       }
 
       // Find show/hide content by id
-      return $('#' + id);
+      return $('#' + id)
     }
 
     // Show toggled content for control
-    function showToggledContent($control, $content) {
+    function showToggledContent ($control, $content) {
 
       // Show content
       if ($content.hasClass('js-hidden')) {
-        $content.removeClass('js-hidden');
-        $content.attr('aria-hidden', 'false');
+        $content.removeClass('js-hidden')
+        $content.attr('aria-hidden', 'false')
 
         // If the controlling input, update aria-expanded
         if ($control.attr('aria-controls')) {
-          $control.attr('aria-expanded', 'true');
+          $control.attr('aria-expanded', 'true')
         }
       }
     }
 
     // Hide toggled content for control
-    function hideToggledContent($control, $content) {
-      $content = $content || getToggledContent($control);
+    function hideToggledContent ($control, $content) {
+      $content = $content || getToggledContent($control)
 
       // Hide content
       if (!$content.hasClass('js-hidden')) {
-        $content.addClass('js-hidden');
-        $content.attr('aria-hidden', 'true');
+        $content.addClass('js-hidden')
+        $content.attr('aria-hidden', 'true')
 
         // If the controlling input, update aria-expanded
         if ($control.attr('aria-controls')) {
-          $control.attr('aria-expanded', 'false');
+          $control.attr('aria-expanded', 'false')
         }
       }
     }
 
     // Handle radio show/hide
-    function handleRadioContent($control, $content) {
+    function handleRadioContent ($control, $content) {
 
       // All radios in this group
-      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + ']';
-      var $radios = $control.closest('form').find(selector);
+      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + ']'
+      var $radios = $control.closest('form').find(selector)
 
       // Hide radios in group
-      $radios.each(function() {
-        hideToggledContent($(this));
-      });
+      $radios.each(function () {
+        hideToggledContent($(this))
+      })
 
       // Select radio button content
-      showToggledContent($control, $content);
+      showToggledContent($control, $content)
     }
 
     // Handle checkbox show/hide
-    function handleCheckboxContent($control, $content) {
+    function handleCheckboxContent ($control, $content) {
 
       // Show checkbox content
       if ($control.is(':checked')) {
-        showToggledContent($control, $content);
+        showToggledContent($control, $content)
       }
 
       // Hide checkbox content
       else {
-        hideToggledContent($control, $content);
+        hideToggledContent($control, $content)
       }
     }
 
     // Set up event handlers etc
-    function init($container, selector, handler) {
-      $container = $container || $(document.body);
+    function init ($container, selector, handler) {
+      $container = $container || $(document.body)
 
       // Handle control clicks
-      function deferred() {
-        var $control = $(this);
-        handler($control, getToggledContent($control));
+      function deferred () {
+        var $control = $(this)
+        handler($control, getToggledContent($control))
       }
 
       // Prepare ARIA attributes
-      var $controls = $(selector);
-      $controls.each(initToggledContent);
+      var $controls = $(selector)
+      $controls.each(initToggledContent)
 
       // Handle events
-      $container.on('click.' + selectors.namespace, selector, deferred);
+      $container.on('click.' + selectors.namespace, selector, deferred)
 
       // Any already :checked on init?
       if ($controls.is(':checked')) {
-        $controls.filter(':checked').each(deferred);
+        $controls.filter(':checked').each(deferred)
       }
     }
 
     // Set up radio show/hide content for container
-    self.showHideRadioToggledContent = function($container) {
-      init($container, selectors.radio, handleRadioContent);
-    };
+    self.showHideRadioToggledContent = function ($container) {
+      init($container, selectors.radio, handleRadioContent)
+    }
 
     // Set up checkbox show/hide content for container
-    self.showHideCheckboxToggledContent = function($container) {
-      init($container, selectors.checkbox, handleCheckboxContent);
-    };
+    self.showHideCheckboxToggledContent = function ($container) {
+      init($container, selectors.checkbox, handleCheckboxContent)
+    }
 
     // Remove event handlers
-    self.destroy = function($container) {
-      $container = $container || $(document.body);
-      $container.off('.' + selectors.namespace);
-    };
+    self.destroy = function ($container) {
+      $container = $container || $(document.body)
+      $container.off('.' + selectors.namespace)
+    }
   }
 
-  ShowHideContent.prototype.init = function($container) {
-    this.showHideRadioToggledContent($container);
-    this.showHideCheckboxToggledContent($container);
-  };
+  ShowHideContent.prototype.init = function ($container) {
+    this.showHideRadioToggledContent($container)
+    this.showHideCheckboxToggledContent($container)
+  }
 
-  GOVUK.ShowHideContent = ShowHideContent;
-  global.GOVUK = GOVUK;
-})(window);
+  GOVUK.ShowHideContent = ShowHideContent
+  global.GOVUK = GOVUK
+})(window)

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -35,8 +35,15 @@
 
     // Return toggled content for control
     function getToggledContent($control) {
-      var $label = $control.parent('label');
-      return $('#' + $label.data('target'));
+      var id = $control.attr('aria-controls');
+
+      // ARIA attributes aren't set before init
+      if (!id) {
+        id = $control.parent('label').data('target');
+      }
+
+      // Find show/hide content by id
+      return $('#' + id);
     }
 
     // Show toggled content for control

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -17,7 +17,7 @@
     // Escape name attribute for use in DOM selector
     function escapeElementName (str) {
       var result = str.replace('[', '\\[').replace(']', '\\]')
-      return (result)
+      return result
     }
 
     // Adds ARIA attributes to control + associated content

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -39,7 +39,7 @@
 
       // ARIA attributes aren't set before init
       if (!id) {
-        id = $control.parent('label').data('target')
+        id = $control.closest('label').data('target')
       }
 
       // Find show/hide content by id

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -78,7 +78,6 @@
 
     // Handle radio show/hide
     function handleRadioContent ($control, $content) {
-
       // All radios in this group which control content
       var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + '][aria-controls]'
       var $radios = $control.closest('form').find(selector)
@@ -99,10 +98,7 @@
       // Show checkbox content
       if ($control.is(':checked')) {
         showToggledContent($control, $content)
-      }
-
-      // Hide checkbox content
-      else {
+      } else { // Hide checkbox content
         hideToggledContent($control, $content)
       }
     }

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -1,0 +1,150 @@
+(function (global) {
+  'use strict';
+
+  var $ = global.jQuery;
+  var GOVUK = global.GOVUK || {};
+
+  function ShowHideContent() {
+    var self = this;
+
+    // Radio and Checkbox selectors
+    var selectors = {
+      namespace: 'ShowHideContent',
+      radio: '.block-label input[type="radio"]',
+      checkbox: '.block-label input[type="checkbox"]'
+    };
+
+    // Escape name attribute for use in DOM selector
+    function escapeElementName(str) {
+      var result = str.replace('[', '\\[').replace(']', '\\]');
+      return(result);
+    }
+
+    // Adds ARIA attributes to control + associated content
+    function initToggledContent() {
+      var $control = $(this);
+      var $content = getToggledContent($control);
+
+      // Set aria-controls and defaults
+      if ($content.length) {
+        $control.attr('aria-controls', $content.attr('id'));
+        $control.attr('aria-expanded', 'false');
+        $content.attr('aria-hidden', 'true');
+      }
+    }
+
+    // Return toggled content for control
+    function getToggledContent($control) {
+      var $label = $control.parent('label');
+      return $('#' + $label.data('target'));
+    }
+
+    // Show toggled content for control
+    function showToggledContent($control, $content) {
+
+      // Show content
+      if ($content.hasClass('js-hidden')) {
+        $content.removeClass('js-hidden');
+        $content.attr('aria-hidden', 'false');
+
+        // If the controlling input, update aria-expanded
+        if ($control.attr('aria-controls')) {
+          $control.attr('aria-expanded', 'true');
+        }
+      }
+    }
+
+    // Hide toggled content for control
+    function hideToggledContent($control, $content) {
+      $content = $content || getToggledContent($control);
+
+      // Hide content
+      if (!$content.hasClass('js-hidden')) {
+        $content.addClass('js-hidden');
+        $content.attr('aria-hidden', 'true');
+
+        // If the controlling input, update aria-expanded
+        if ($control.attr('aria-controls')) {
+          $control.attr('aria-expanded', 'false');
+        }
+      }
+    }
+
+    // Handle radio show/hide
+    function handleRadioContent($control, $content) {
+
+      // All radios in this group
+      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + ']';
+      var $radios = $control.closest('form').find(selector);
+
+      // Hide radios in group
+      $radios.each(function() {
+        hideToggledContent($(this));
+      });
+
+      // Select radio button content
+      showToggledContent($control, $content);
+    }
+
+    // Handle checkbox show/hide
+    function handleCheckboxContent($control, $content) {
+
+      // Show checkbox content
+      if ($control.is(':checked')) {
+        showToggledContent($control, $content);
+      }
+
+      // Hide checkbox content
+      else {
+        hideToggledContent($control, $content);
+      }
+    }
+
+    // Set up event handlers etc
+    function init($container, selector, handler) {
+      $container = $container || $(document.body);
+
+      // Handle control clicks
+      function deferred() {
+        var $control = $(this);
+        handler($control, getToggledContent($control));
+      }
+
+      // Prepare ARIA attributes
+      var $controls = $(selector);
+      $controls.each(initToggledContent);
+
+      // Handle events
+      $container.on('click.' + selectors.namespace, selector, deferred);
+
+      // Any already :checked on init?
+      if ($controls.is(':checked')) {
+        $controls.filter(':checked').each(deferred);
+      }
+    }
+
+    // Set up radio show/hide content for container
+    self.showHideRadioToggledContent = function($container) {
+      init($container, selectors.radio, handleRadioContent);
+    };
+
+    // Set up checkbox show/hide content for container
+    self.showHideCheckboxToggledContent = function($container) {
+      init($container, selectors.checkbox, handleCheckboxContent);
+    };
+
+    // Remove event handlers
+    self.destroy = function($container) {
+      $container = $container || $(document.body);
+      $container.off('.' + selectors.namespace);
+    };
+  }
+
+  ShowHideContent.prototype.init = function($container) {
+    this.showHideRadioToggledContent($container);
+    this.showHideCheckboxToggledContent($container);
+  };
+
+  GOVUK.ShowHideContent = ShowHideContent;
+  global.GOVUK = GOVUK;
+})(window);

--- a/spec/manifest.js
+++ b/spec/manifest.js
@@ -1,12 +1,13 @@
 // Paths are relative to the /spec/support folder
 var manifest = {
-  support : [
+  support: [
     '../../node_modules/jquery/dist/jquery.js',
     '../../javascripts/govuk/modules.js',
     '../../javascripts/govuk/modules/auto-track-event.js',
     '../../javascripts/govuk/multivariate-test.js',
     '../../javascripts/govuk/primary-links.js',
     '../../javascripts/govuk/shim-links-with-button-role.js',
+    '../../javascripts/govuk/show-hide-content.js',
     '../../javascripts/govuk/stick-at-top-when-scrolling.js',
     '../../javascripts/govuk/stop-scrolling-at-footer.js',
     '../../javascripts/govuk/selection-buttons.js',
@@ -17,12 +18,13 @@ var manifest = {
     '../../javascripts/govuk/analytics/download-link-tracker.js',
     '../../javascripts/govuk/analytics/mailto-link-tracker.js'
   ],
-  test : [
+  test: [
     '../unit/modules.spec.js',
     '../unit/Modules/auto-track-event.spec.js',
     '../unit/multivariate-test.spec.js',
     '../unit/primary-links.spec.js',
     '../unit/shim-links-with-button-role.spec.js',
+    '../unit/show-hide-content.spec.js',
     '../unit/stick-at-top-when-scrolling.spec.js',
     '../unit/selection-button.spec.js',
     '../unit/analytics/google-analytics-universal-tracker.spec.js',
@@ -32,4 +34,4 @@ var manifest = {
     '../unit/analytics/download-link-tracker.spec.js',
     '../unit/analytics/mailto-link-tracker.spec.js'
   ]
-};
+}

--- a/spec/support/LocalTestRunner.html
+++ b/spec/support/LocalTestRunner.html
@@ -3,16 +3,16 @@
 <head>
   <title>Jasmine Test Runner</title>
 
-  <link rel="stylesheet" type="text/css" href="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
+  <link rel="stylesheet" type="text/css" href="../../node_modules/grunt-contrib-jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.css">
   <style>
     #wrapper { display: none; }
   </style>
 
   <!-- JASMINE FILES -->
-  <script type="text/javascript" src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
-  <script type="text/javascript" src="../../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js"></script>
 
-  <script type="text/javascript" src="../../node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
+  <script type="text/javascript" src="../../node_modules/grunt-contrib-jasmine/node_modules/jasmine-core/lib/jasmine-core/boot.js"></script>
   <script type="text/javascript" src="./load.js"></script>
 </head>
 <body>

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -7,7 +7,7 @@ describe('show-hide-content', function () {
     this.$content = $(
 
       // Radio buttons (yes/no)
-      '<form class="js-toggle-showhide">' +
+      '<form>' +
       '<label class="block-label" data-target="show-hide-radios">' +
       '<input type="radio" name="single" value="no">' +
       'Yes' +
@@ -20,7 +20,7 @@ describe('show-hide-content', function () {
       '</form>' +
 
       // Checkboxes (multiple values)
-      '<form class="js-toggle-showhide">' +
+      '<form>' +
       '<label class="block-label" data-target="show-hide-checkboxes">' +
       '<input type="checkbox" name="multiple[option1]">' +
       'Option 1' +

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -216,11 +216,11 @@ describe('show-hide-content', function () {
       var events = $._data(document.body, 'events')
       expect(events && events.click).toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
-        selector: '.block-label input[type="radio"]'
+        selector: 'input[type="radio"][name="single"]'
       }))
       expect(events && events.click).toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
-        selector: '.block-label input[type="checkbox"]'
+        selector: '.block-label[data-target] input[type="checkbox"]'
       }))
     })
   })
@@ -234,11 +234,11 @@ describe('show-hide-content', function () {
       var events = $._data(document.body, 'events')
       expect(events && events.click).not.toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
-        selector: '.block-label input[type="radio"]'
+        selector: 'input[type="radio"][name="single"]'
       }))
       expect(events && events.click).not.toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
-        selector: '.block-label input[type="checkbox"]'
+        selector: '.block-label[data-target] input[type="checkbox"]'
       }))
     })
   })

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -1,0 +1,246 @@
+describe('show-hide-content', function() {
+  'use strict';
+
+  beforeEach(function() {
+
+    // Sample markup
+    this.$content = $(
+
+      // Radio buttons (yes/no)
+      '<form>' +
+        '<label class="block-label" data-target="show-hide-radios">' +
+          '<input type="radio" name="single" value="no">' +
+          'Yes' +
+        '</label>' +
+        '<label class="block-label">' +
+          '<input type="radio" name="single" value="yes">' +
+          'No' +
+        '</label>' +
+        '<div id="show-hide-radios" class="panel js-hidden" />' +
+      '</form>' +
+
+      // Checkboxes (multiple values)
+      '<form>' +
+        '<label class="block-label" data-target="show-hide-checkboxes">' +
+          '<input type="checkbox" name="multiple[option1]">' +
+          'Option 1' +
+        '</label>' +
+        '<label class="block-label">' +
+          '<input type="checkbox" name="multiple[option2]">' +
+          'Option 2' +
+        '</label>' +
+        '<label class="block-label">' +
+          '<input type="checkbox" name="multiple[option3]">' +
+          'Option 3' +
+        '</label>' +
+        '<div id="show-hide-checkboxes" class="panel js-hidden" />' +
+      '</form>'
+    );
+
+    // Find radios/checkboxes
+    var $radios = this.$content.find('input[type=radio]');
+    var $checkboxes = this.$content.find('input[type=checkbox]');
+
+    // Two radios
+    this.$radio1 = $radios.eq(0);
+    this.$radio2 = $radios.eq(1);
+
+    // Three checkboxes
+    this.$checkbox1 = $checkboxes.eq(0);
+    this.$checkbox2 = $checkboxes.eq(1);
+    this.$checkbox3 = $checkboxes.eq(2);
+
+    // Add to page
+    $(document.body).append(this.$content);
+
+    // Show/Hide content
+    this.$radioShowHide = $('#show-hide-radios');
+    this.$checkboxShowHide = $('#show-hide-checkboxes');
+
+    // Add show/hide content support
+    this.showHideContent = new GOVUK.ShowHideContent();
+    this.showHideContent.init();
+  });
+
+  afterEach(function() {
+    if (this.showHideContent) {
+      this.showHideContent.destroy();
+    }
+
+    this.$content.remove();
+  });
+
+  describe('when this.showHideContent = new GOVUK.ShowHideContent() is called', function() {
+    it('should add the aria attributes to inputs with show/hide content', function() {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false');
+      expect(this.$radio1.attr('aria-controls')).toBe('show-hide-radios');
+    });
+
+    it('should add the aria attributes to show/hide content', function() {
+      expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
+      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
+    });
+
+    it('should hide the show/hide content visually', function() {
+      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
+    });
+
+    it('should do nothing if no radios are checked', function() {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false');
+      expect(this.$radio2.attr('aria-expanded')).toBe(undefined);
+    });
+
+    it('should do nothing if no checkboxes are checked', function() {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false');
+      expect(this.$radio2.attr('aria-expanded')).toBe(undefined);
+    });
+
+    describe('with non-default markup', function() {
+      beforeEach(function() {
+        this.showHideContent.destroy();
+      });
+
+      it('should do nothing if a radio without show/hide content is checked', function() {
+        this.$radio2.prop('checked', true);
+
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init();
+        expect(this.$radio1.attr('aria-expanded')).toBe('false');
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
+      });
+
+      it('should do nothing if a checkbox without show/hide content is checked', function() {
+        this.$checkbox2.prop('checked', true);
+
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init();
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('false');
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true');
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true);
+      });
+
+      it('should do nothing if checkboxes without show/hide content is checked', function() {
+        this.$checkbox2.prop('checked', true);
+        this.$checkbox3.prop('checked', true);
+
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init();
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('false');
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true');
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true);
+      });
+
+      it('should make the show/hide content visible if its radio is checked', function() {
+        this.$radio1.prop('checked', true);
+
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init();
+        expect(this.$radio1.attr('aria-expanded')).toBe('true');
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false');
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+
+      it('should make the show/hide content visible if its checkbox is checked', function() {
+        this.$checkbox1.prop('checked', true);
+
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init();
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+    });
+
+    describe('and a show/hide radio receives a click', function() {
+      it('should make the show/hide content visible', function() {
+        this.$radio1.click();
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+
+      it('should add the aria attributes to show/hide content', function() {
+        this.$radio1.click();
+        expect(this.$radio1.attr('aria-expanded')).toBe('true');
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false');
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+    });
+
+    describe('and a show/hide checkbox receives a click', function() {
+      it('should make the show/hide content visible', function() {
+        this.$checkbox1.click();
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+
+      it('should add the aria attributes to show/hide content', function() {
+        this.$checkbox1.click();
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+    });
+
+    describe('and a show/hide radio receives a click, but another group radio is clicked afterwards', function() {
+      it('should make the show/hide content visible', function() {
+        this.$radio1.click();
+        this.$radio2.click();
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
+      });
+
+      it('should add the aria attributes to show/hide content', function() {
+        this.$radio1.click();
+        this.$radio2.click();
+        expect(this.$radio1.attr('aria-expanded')).toBe('false');
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
+      });
+    });
+
+    describe('and a show/hide checkbox receives a click, but another checkbox is clicked afterwards', function() {
+      it('should keep the show/hide content visible', function() {
+        this.$checkbox1.click();
+        this.$checkbox2.click();
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
+      });
+
+      it('should keep the aria attributes to show/hide content', function() {
+        this.$checkbox1.click();
+        this.$checkbox2.click();
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
+      });
+    });
+  });
+
+  describe('before this.showHideContent.destroy() is called', function() {
+
+    it('document.body should have show/hide event handlers', function() {
+      var events = $._data(document.body, 'events');
+      expect(events && events.click).toContain(jasmine.objectContaining({
+        namespace: 'ShowHideContent',
+        selector: '.block-label input[type="radio"]'
+      }));
+      expect(events && events.click).toContain(jasmine.objectContaining({
+        namespace: 'ShowHideContent',
+        selector: '.block-label input[type="checkbox"]'
+      }));
+    });
+  });
+
+  describe('when this.showHideContent.destroy() is called', function() {
+    beforeEach(function() {
+      this.showHideContent.destroy();
+    });
+
+    it('should have no show/hide event handlers', function() {
+      var events = $._data(document.body, 'events');
+      expect(events && events.click).not.toContain(jasmine.objectContaining({
+        namespace: 'ShowHideContent',
+        selector: '.block-label input[type="radio"]'
+      }));
+      expect(events && events.click).not.toContain(jasmine.objectContaining({
+        namespace: 'ShowHideContent',
+        selector: '.block-label input[type="checkbox"]'
+      }));
+    });
+  });
+});

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -1,246 +1,245 @@
-describe('show-hide-content', function() {
-  'use strict';
+describe('show-hide-content', function () {
+  'use strict'
 
-  beforeEach(function() {
+  beforeEach(function () {
 
     // Sample markup
     this.$content = $(
 
       // Radio buttons (yes/no)
-      '<form>' +
-        '<label class="block-label" data-target="show-hide-radios">' +
-          '<input type="radio" name="single" value="no">' +
-          'Yes' +
-        '</label>' +
-        '<label class="block-label">' +
-          '<input type="radio" name="single" value="yes">' +
-          'No' +
-        '</label>' +
-        '<div id="show-hide-radios" class="panel js-hidden" />' +
+      '<form class="js-toggle-showhide">' +
+      '<label class="block-label" data-target="show-hide-radios">' +
+      '<input type="radio" name="single" value="no">' +
+      'Yes' +
+      '</label>' +
+      '<label class="block-label">' +
+      '<input type="radio" name="single" value="yes">' +
+      'No' +
+      '</label>' +
+      '<div id="show-hide-radios" class="panel js-hidden" />' +
       '</form>' +
 
       // Checkboxes (multiple values)
-      '<form>' +
-        '<label class="block-label" data-target="show-hide-checkboxes">' +
-          '<input type="checkbox" name="multiple[option1]">' +
-          'Option 1' +
-        '</label>' +
-        '<label class="block-label">' +
-          '<input type="checkbox" name="multiple[option2]">' +
-          'Option 2' +
-        '</label>' +
-        '<label class="block-label">' +
-          '<input type="checkbox" name="multiple[option3]">' +
-          'Option 3' +
-        '</label>' +
-        '<div id="show-hide-checkboxes" class="panel js-hidden" />' +
+      '<form class="js-toggle-showhide">' +
+      '<label class="block-label" data-target="show-hide-checkboxes">' +
+      '<input type="checkbox" name="multiple[option1]">' +
+      'Option 1' +
+      '</label>' +
+      '<label class="block-label">' +
+      '<input type="checkbox" name="multiple[option2]">' +
+      'Option 2' +
+      '</label>' +
+      '<label class="block-label">' +
+      '<input type="checkbox" name="multiple[option3]">' +
+      'Option 3' +
+      '</label>' +
+      '<div id="show-hide-checkboxes" class="panel js-hidden" />' +
       '</form>'
-    );
+    )
 
     // Find radios/checkboxes
-    var $radios = this.$content.find('input[type=radio]');
-    var $checkboxes = this.$content.find('input[type=checkbox]');
+    var $radios = this.$content.find('input[type=radio]')
+    var $checkboxes = this.$content.find('input[type=checkbox]')
 
     // Two radios
-    this.$radio1 = $radios.eq(0);
-    this.$radio2 = $radios.eq(1);
+    this.$radio1 = $radios.eq(0)
+    this.$radio2 = $radios.eq(1)
 
     // Three checkboxes
-    this.$checkbox1 = $checkboxes.eq(0);
-    this.$checkbox2 = $checkboxes.eq(1);
-    this.$checkbox3 = $checkboxes.eq(2);
+    this.$checkbox1 = $checkboxes.eq(0)
+    this.$checkbox2 = $checkboxes.eq(1)
+    this.$checkbox3 = $checkboxes.eq(2)
 
     // Add to page
-    $(document.body).append(this.$content);
+    $(document.body).append(this.$content)
 
     // Show/Hide content
-    this.$radioShowHide = $('#show-hide-radios');
-    this.$checkboxShowHide = $('#show-hide-checkboxes');
+    this.$radioShowHide = $('#show-hide-radios')
+    this.$checkboxShowHide = $('#show-hide-checkboxes')
 
     // Add show/hide content support
-    this.showHideContent = new GOVUK.ShowHideContent();
-    this.showHideContent.init();
-  });
+    this.showHideContent = new GOVUK.ShowHideContent()
+    this.showHideContent.init()
+  })
 
-  afterEach(function() {
+  afterEach(function () {
     if (this.showHideContent) {
-      this.showHideContent.destroy();
+      this.showHideContent.destroy()
     }
 
-    this.$content.remove();
-  });
+    this.$content.remove()
+  })
 
-  describe('when this.showHideContent = new GOVUK.ShowHideContent() is called', function() {
-    it('should add the aria attributes to inputs with show/hide content', function() {
-      expect(this.$radio1.attr('aria-expanded')).toBe('false');
-      expect(this.$radio1.attr('aria-controls')).toBe('show-hide-radios');
-    });
+  describe('when this.showHideContent = new GOVUK.ShowHideContent() is called', function () {
+    it('should add the aria attributes to inputs with show/hide content', function () {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false')
+      expect(this.$radio1.attr('aria-controls')).toBe('show-hide-radios')
+    })
 
-    it('should add the aria attributes to show/hide content', function() {
-      expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
-      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
-    });
+    it('should add the aria attributes to show/hide content', function () {
+      expect(this.$radioShowHide.attr('aria-hidden')).toBe('true')
+      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true)
+    })
 
-    it('should hide the show/hide content visually', function() {
-      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
-    });
+    it('should hide the show/hide content visually', function () {
+      expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true)
+    })
 
-    it('should do nothing if no radios are checked', function() {
-      expect(this.$radio1.attr('aria-expanded')).toBe('false');
-      expect(this.$radio2.attr('aria-expanded')).toBe(undefined);
-    });
+    it('should do nothing if no radios are checked', function () {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false')
+      expect(this.$radio2.attr('aria-expanded')).toBe(undefined)
+    })
 
-    it('should do nothing if no checkboxes are checked', function() {
-      expect(this.$radio1.attr('aria-expanded')).toBe('false');
-      expect(this.$radio2.attr('aria-expanded')).toBe(undefined);
-    });
+    it('should do nothing if no checkboxes are checked', function () {
+      expect(this.$radio1.attr('aria-expanded')).toBe('false')
+      expect(this.$radio2.attr('aria-expanded')).toBe(undefined)
+    })
 
-    describe('with non-default markup', function() {
-      beforeEach(function() {
-        this.showHideContent.destroy();
-      });
+    describe('with non-default markup', function () {
+      beforeEach(function () {
+        this.showHideContent.destroy()
+      })
 
-      it('should do nothing if a radio without show/hide content is checked', function() {
-        this.$radio2.prop('checked', true);
-
-        // Defaults changed, initialise again
-        this.showHideContent = new GOVUK.ShowHideContent().init();
-        expect(this.$radio1.attr('aria-expanded')).toBe('false');
-        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
-        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
-      });
-
-      it('should do nothing if a checkbox without show/hide content is checked', function() {
-        this.$checkbox2.prop('checked', true);
+      it('should do nothing if a radio without show/hide content is checked', function () {
+        this.$radio2.prop('checked', true)
 
         // Defaults changed, initialise again
-        this.showHideContent = new GOVUK.ShowHideContent().init();
-        expect(this.$checkbox1.attr('aria-expanded')).toBe('false');
-        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true');
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true);
-      });
+        this.showHideContent = new GOVUK.ShowHideContent().init()
+        expect(this.$radio1.attr('aria-expanded')).toBe('false')
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true')
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true)
+      })
 
-      it('should do nothing if checkboxes without show/hide content is checked', function() {
-        this.$checkbox2.prop('checked', true);
-        this.$checkbox3.prop('checked', true);
-
-        // Defaults changed, initialise again
-        this.showHideContent = new GOVUK.ShowHideContent().init();
-        expect(this.$checkbox1.attr('aria-expanded')).toBe('false');
-        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true');
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true);
-      });
-
-      it('should make the show/hide content visible if its radio is checked', function() {
-        this.$radio1.prop('checked', true);
+      it('should do nothing if a checkbox without show/hide content is checked', function () {
+        this.$checkbox2.prop('checked', true)
 
         // Defaults changed, initialise again
-        this.showHideContent = new GOVUK.ShowHideContent().init();
-        expect(this.$radio1.attr('aria-expanded')).toBe('true');
-        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false');
-        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
-      });
+        this.showHideContent = new GOVUK.ShowHideContent().init()
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('false')
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true')
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true)
+      })
 
-      it('should make the show/hide content visible if its checkbox is checked', function() {
-        this.$checkbox1.prop('checked', true);
+      it('should do nothing if checkboxes without show/hide content is checked', function () {
+        this.$checkbox2.prop('checked', true)
+        this.$checkbox3.prop('checked', true)
 
         // Defaults changed, initialise again
-        this.showHideContent = new GOVUK.ShowHideContent().init();
-        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
-        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
-      });
-    });
+        this.showHideContent = new GOVUK.ShowHideContent().init()
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('false')
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('true')
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(true)
+      })
 
-    describe('and a show/hide radio receives a click', function() {
-      it('should make the show/hide content visible', function() {
-        this.$radio1.click();
-        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
-      });
+      it('should make the show/hide content visible if its radio is checked', function () {
+        this.$radio1.prop('checked', true)
 
-      it('should add the aria attributes to show/hide content', function() {
-        this.$radio1.click();
-        expect(this.$radio1.attr('aria-expanded')).toBe('true');
-        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false');
-        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false);
-      });
-    });
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init()
+        expect(this.$radio1.attr('aria-expanded')).toBe('true')
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false')
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false)
+      })
 
-    describe('and a show/hide checkbox receives a click', function() {
-      it('should make the show/hide content visible', function() {
-        this.$checkbox1.click();
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
-      });
+      it('should make the show/hide content visible if its checkbox is checked', function () {
+        this.$checkbox1.prop('checked', true)
 
-      it('should add the aria attributes to show/hide content', function() {
-        this.$checkbox1.click();
-        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
-        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
-      });
-    });
+        // Defaults changed, initialise again
+        this.showHideContent = new GOVUK.ShowHideContent().init()
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false')
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false)
+      })
+    })
 
-    describe('and a show/hide radio receives a click, but another group radio is clicked afterwards', function() {
-      it('should make the show/hide content visible', function() {
-        this.$radio1.click();
-        this.$radio2.click();
-        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true);
-      });
+    describe('and a show/hide radio receives a click', function () {
+      it('should make the show/hide content visible', function () {
+        this.$radio1.click()
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false)
+      })
 
-      it('should add the aria attributes to show/hide content', function() {
-        this.$radio1.click();
-        this.$radio2.click();
-        expect(this.$radio1.attr('aria-expanded')).toBe('false');
-        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true');
-      });
-    });
+      it('should add the aria attributes to show/hide content', function () {
+        this.$radio1.click()
+        expect(this.$radio1.attr('aria-expanded')).toBe('true')
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('false')
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(false)
+      })
+    })
 
-    describe('and a show/hide checkbox receives a click, but another checkbox is clicked afterwards', function() {
-      it('should keep the show/hide content visible', function() {
-        this.$checkbox1.click();
-        this.$checkbox2.click();
-        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false);
-      });
+    describe('and a show/hide checkbox receives a click', function () {
+      it('should make the show/hide content visible', function () {
+        this.$checkbox1.click()
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false)
+      })
 
-      it('should keep the aria attributes to show/hide content', function() {
-        this.$checkbox1.click();
-        this.$checkbox2.click();
-        expect(this.$checkbox1.attr('aria-expanded')).toBe('true');
-        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false');
-      });
-    });
-  });
+      it('should add the aria attributes to show/hide content', function () {
+        this.$checkbox1.click()
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false')
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false)
+      })
+    })
 
-  describe('before this.showHideContent.destroy() is called', function() {
+    describe('and a show/hide radio receives a click, but another group radio is clicked afterwards', function () {
+      it('should make the show/hide content hidden', function () {
+        this.$radio1.click()
+        this.$radio2.click()
+        expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true)
+      })
 
-    it('document.body should have show/hide event handlers', function() {
-      var events = $._data(document.body, 'events');
+      it('should add the aria attributes to show/hide content', function () {
+        this.$radio1.click()
+        this.$radio2.click()
+        expect(this.$radio1.attr('aria-expanded')).toBe('false')
+        expect(this.$radioShowHide.attr('aria-hidden')).toBe('true')
+      })
+    })
+
+    describe('and a show/hide checkbox receives a click, but another checkbox is clicked afterwards', function () {
+      it('should keep the show/hide content visible', function () {
+        this.$checkbox1.click()
+        this.$checkbox2.click()
+        expect(this.$checkboxShowHide.hasClass('js-hidden')).toEqual(false)
+      })
+
+      it('should keep the aria attributes to show/hide content', function () {
+        this.$checkbox1.click()
+        this.$checkbox2.click()
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+        expect(this.$checkboxShowHide.attr('aria-hidden')).toBe('false')
+      })
+    })
+  })
+
+  describe('before this.showHideContent.destroy() is called', function () {
+    it('document.body should have show/hide event handlers', function () {
+      var events = $._data(document.body, 'events')
       expect(events && events.click).toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
         selector: '.block-label input[type="radio"]'
-      }));
+      }))
       expect(events && events.click).toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
         selector: '.block-label input[type="checkbox"]'
-      }));
-    });
-  });
+      }))
+    })
+  })
 
-  describe('when this.showHideContent.destroy() is called', function() {
-    beforeEach(function() {
-      this.showHideContent.destroy();
-    });
+  describe('when this.showHideContent.destroy() is called', function () {
+    beforeEach(function () {
+      this.showHideContent.destroy()
+    })
 
-    it('should have no show/hide event handlers', function() {
-      var events = $._data(document.body, 'events');
+    it('should have no show/hide event handlers', function () {
+      var events = $._data(document.body, 'events')
       expect(events && events.click).not.toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
         selector: '.block-label input[type="radio"]'
-      }));
+      }))
       expect(events && events.click).not.toContain(jasmine.objectContaining({
         namespace: 'ShowHideContent',
         selector: '.block-label input[type="checkbox"]'
-      }));
-    });
-  });
-});
+      }))
+    })
+  })
+})


### PR DESCRIPTION
Add GOVUK.ShowHideContent to toolkit, this is copied from #305.
This PR is rebased against master and has  the conflicts from #305 resolved. 

A link is added to the README to the documentation.
Standard JS has been used to lint the JS.

cc. @tombye, @nickcolley.