### PR TITLE
Close the example code block

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -430,6 +430,7 @@ It’s also possible to define more or different keycodes to activate against:
 GOVUK.shimLinksWithButtonRole.init({
   keycodes: [32, 114]
 });
+```
 
 ## Show/Hide content
 


### PR DESCRIPTION
This PR adds the missing line to close the example block.

Screenshot before:

![example-before](https://cloud.githubusercontent.com/assets/417754/18248485/639743c8-7370-11e6-9ca3-32a2dab854a0.png)

Screenshot after:

![screenshot-after](https://cloud.githubusercontent.com/assets/417754/18248513/88026440-7370-11e6-8b8e-8b65c3d4938c.png)
