### PR TITLE
Fix link to the show/hide content docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ In production:
   * [Stick at top when scrolling](/docs/javascript.md#stick-at-top-when-scrolling)
   * [Selection buttons](/docs/javascript.md#selection-buttons)
   * [Shim links with button role](/docs/javascript.md#shim-links-with-button-role)
-  * [Show/Hide content](/docs/javascript.md#show-hide-content)
+  * [Show/Hide content](/docs/javascript.md#showhide-content)
 * [Analytics](/docs/analytics.md)
   * [Create an analytics tracker](/docs/analytics.md#create-an-analytics-tracker)
   * [Virtual pageviews](/docs/analytics.md#virtual-pageviews)


### PR DESCRIPTION
Using a `/` between the two words has meant they aren't separated by a hyphen, this PR fixes that - so the docs can be reached from the README.
