### PR TITLE
Remove stray comma causing an error in IE

### DIFF
--- a/javascripts/govuk/shim-links-with-button-role.js
+++ b/javascripts/govuk/shim-links-with-button-role.js
@@ -23,7 +23,7 @@
       // array of keys to match against upon the keyup event
       keycodes: [
         32 // spacekey
-      ],
+      ]
     },
 
     // event behaviour (not a typical anonymous function for resuse if needed)


### PR DESCRIPTION
This can seen on GOV.UK elements here: http://govuk-elements.herokuapp.com/.

![screen shot 2016-09-06 at 12 28 41](https://cloud.githubusercontent.com/assets/417754/18272072/9c18adb4-742d-11e6-9332-461f68463eeb.png)

Removing this comma fixes the error.

--

Steps taken to test this:

Run govuk elements locally, open http://localhost:3000 in Browserstack and you will see this error.

Removing the stray comma from /node_modules/govuk_frontend_toolkit/javascripts/govuk/shim-links-with-button-role.js and re-running the app fixes this.

Using npm update (to reset the toolkit) and then running the app again brings the error back.

--

This would have been caught if we'd used a linter, I've opened separate PR to lint this file using Standard #324.