### PR TITLE
Remove grunt-shell dependency and use npm script

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -49,16 +49,8 @@ module.exports = function(grunt) {
           loadPath: [
             './stylesheets'
           ],
-          style: 'nested',
+          style: 'nested'
         }
-      },
-    },
-    shell: {
-      multiple: {
-        command: [
-          'bundle',
-          'bundle exec govuk-lint-sass stylesheets'
-        ].join('&&')
       }
     }
   });
@@ -66,8 +58,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-clean');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-contrib-sass');
-  grunt.loadNpmTasks('grunt-shell');
 
-  grunt.registerTask('test', ['sass', 'clean', 'jasmine', 'shell']);
+  grunt.registerTask('test', ['sass', 'clean', 'jasmine']);
   grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "jquery": "~1.11.3"
   },
   "scripts": {
-    "test": "grunt test && npm run lint",
+    "test": "grunt test && npm run lint --silent",
     "lint": "bundle && bundle exec govuk-lint-sass stylesheets"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
     "grunt-contrib-clean":"~0.6.0",
     "grunt-contrib-jasmine": "^1.0.0",
     "grunt-contrib-sass": "0.7.4",
-    "grunt-shell": "^1.1.2",
     "jquery": "~1.11.3"
   },
   "scripts": {
-    "test": "node_modules/.bin/grunt test"
+    "test": "grunt test && npm run lint",
+    "lint": "bundle && bundle exec govuk-lint-sass stylesheets"
   }
 }


### PR DESCRIPTION
I can't actually get `npm test` to work on my machine because of the ruby dependencies but this should work.

Should speed up `npm install` by a second or so..

```
--------------------------------------------------
| Dependency            | Time | Size   | # Deps |
--------------------------------------------------
| grunt-contrib-jasmine | 9.8s | 53 MB  | 111    |
| grunt                 | 3.4s | 7.6 MB | 30     |
| grunt-cli             | 1.8s | 1.3 MB | 11     |
| grunt-contrib-sass    | 1.7s | 186 KB | 13     |
| grunt-shell           | 1.6s | 74 KB  | 10     |
| jquery                | 1.3s | 1.3 MB | 0      |
| grunt-contrib-clean   | 1.1s | 23 KB  | 2      |
--------------------------------------------------
```