### PR TITLE
Remove `@media` width query from print styles

### DIFF
--- a/stylesheets/_typography.scss
+++ b/stylesheets/_typography.scss
@@ -35,18 +35,21 @@ $is-print: false !default;
       }
     }
   }
-  font-size: $font-size-640;
-  line-height: $line-height-640;
   font-weight: $font-weight;
   text-transform: none;
 
-  @include media(tablet) {
-    font-size: $font-size;
-    line-height: $line-height;
-  }
-
   @if $is-print {
     font-size: $font-size-print;
+    line-height: $line-height;
+
+  } @else {
+    font-size: $font-size-640;
+    line-height: $line-height-640;
+
+    @include media(tablet) {
+      font-size: $font-size;
+      line-height: $line-height;
+    }
   }
 }
 // scss-lint:enable NameFormat


### PR DESCRIPTION
This fixes that print styles using any of the typography mixins would have font sizes in `px` < 640px width and in `pt` after and sometimes the wrong line-height.
Different browser print views  also have different widths, making the print look less consistent between different browsers.

Please note, I did not test the changes as I don't know how test changes to the frontend toolkit locally.
This should also fix an outstanding issue on alphagov/govuk_template#237.