### PR TITLE
Amend GOVUK.stickAtTopWhenScrolling to "unstick" for smaller screens

### DIFF
--- a/javascripts/govuk/stick-at-top-when-scrolling.js
+++ b/javascripts/govuk/stick-at-top-when-scrolling.js
@@ -9,6 +9,20 @@
     _hasScrolled: false,
     _scrollTimeout: false,
 
+    getWindowDimensions: function() {
+      return {
+        height: $(global).height(),
+        width: $(global).width()
+      };
+    },
+    getWindowPositions: function() {
+      return {
+        scrollTop: $(global).scrollTop()
+      };
+    },
+    getElementOffset: function($el) {
+      return $el.offset()
+    },
     init: function(){
       var $els = $('.js-stick-at-top-when-scrolling');
 
@@ -43,14 +57,17 @@
       if(sticky._hasScrolled === true){
         sticky._hasScrolled = false;
 
-        var windowVerticalPosition = $(global).scrollTop();
+        var windowVerticalPosition = sticky.getWindowPositions().scrollTop;
+
+        var windowDimensions = sticky.getWindowDimensions();
+
         sticky.$els.each(function(i, el){
           var $el = $(el),
               scrolledFrom = $el.data('scrolled-from');
 
           if (scrolledFrom && windowVerticalPosition < scrolledFrom){
             sticky.release($el);
-          } else if($(global).width() > 768 && windowVerticalPosition >= $el.offset().top) {
+          } else if(windowDimensions.width > 768 && windowVerticalPosition >= sticky.getElementOffset($el).top) {
             sticky.stick($el);
           }
         });
@@ -58,7 +75,7 @@
     },
     stick: function($el){
       if (!$el.hasClass('content-fixed')) {
-        $el.data('scrolled-from', $el.offset().top);
+        $el.data('scrolled-from', sticky.getElementOffset($el).top);
         var height = Math.max($el.height(), 1);
         $el.before('<div class="shim" style="width: '+ $el.width() + 'px; height: ' + height + 'px">&nbsp;</div>');
         $el.css('width', $el.width() + "px").addClass('content-fixed');

--- a/javascripts/govuk/stick-at-top-when-scrolling.js
+++ b/javascripts/govuk/stick-at-top-when-scrolling.js
@@ -8,6 +8,8 @@
   var sticky = {
     _hasScrolled: false,
     _scrollTimeout: false,
+    _hasResized: false,
+    _resizeTimeout: false,
 
     getWindowDimensions: function() {
       return {
@@ -33,7 +35,11 @@
           $(global).scroll(sticky.onScroll);
           sticky._scrollTimeout = global.setInterval(sticky.checkScroll, 50);
         }
-        $(global).resize(sticky.onResize);
+
+        if(sticky._resizeTimeout === false) {
+          $(global).resize(sticky.onResize);
+          sticky._resizeTimeout = global.setInterval(sticky.checkResize, 50);
+        }
       }
       if(GOVUK.stopScrollingAtFooter){
         $els.each(function(i,el){
@@ -53,6 +59,9 @@
     onScroll: function(){
       sticky._hasScrolled = true;
     },
+    onResize: function(){
+      sticky._hasResized = true;
+    },
     checkScroll: function(){
       if(sticky._hasScrolled === true){
         sticky._hasScrolled = false;
@@ -69,6 +78,21 @@
             sticky.release($el);
           } else if(windowDimensions.width > 768 && windowVerticalPosition >= sticky.getElementOffset($el).top) {
             sticky.stick($el);
+          }
+        });
+      }
+    },
+    checkResize: function() {
+      if(sticky._hasResized === true){
+        sticky._hasResized = false;
+
+        var windowDimensions = sticky.getWindowDimensions();
+
+        sticky.$els.each(function(i, el){
+          var $el = $(el);
+
+          if(windowDimensions.width <= 768) {
+            sticky.release($el);
           }
         });
       }

--- a/spec/unit/stick-at-top-when-scrolling.spec.js
+++ b/spec/unit/stick-at-top-when-scrolling.spec.js
@@ -13,27 +13,109 @@ describe("stick-at-top-when-scrolling", function(){
     $stickyWrapper.remove();
   });
 
-  it('should add fixed class on stick', function(){
-    expect(!$stickyElement.hasClass('content-fixed')).toBe(true);
-    GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
-    expect($stickyElement.hasClass('content-fixed')).toBe(true);
+  describe('when stick is called', function(){
+
+    it('should add fixed class on stick', function(){
+      expect(!$stickyElement.hasClass('content-fixed')).toBe(true);
+      GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
+      expect($stickyElement.hasClass('content-fixed')).toBe(true);
+    });
+
+    it('should insert shim when sticking the element', function(){
+      expect($('.shim').length).toBe(0);
+      GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
+      expect($('.shim').length).toBe(1);
+    });
+
+    it('should insert shim with minimum height', function(){
+      GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
+      expect($('.shim').height()).toBe(1);
+    });
+
   });
 
-  it('should remove fixed class on release', function(){
-    $stickyElement.addClass('content-fixed');
-    GOVUK.stickAtTopWhenScrolling.release($stickyElement);
-    expect(!$stickyElement.hasClass('content-fixed')).toBe(true);
+  describe('when release is called', function(){
+
+    it('should remove fixed class', function(){
+      $stickyElement.addClass('content-fixed');
+      GOVUK.stickAtTopWhenScrolling.release($stickyElement);
+      expect($stickyElement.hasClass('content-fixed')).toBe(false);
+    });
+
+    it('should remove the shim', function(){
+      $stickyElement = $('<div class="stick-at-top-when-scrolling content-fixed"></div>');
+      GOVUK.stickAtTopWhenScrolling.release($stickyElement);
+      expect($('.shim').length).toBe(0);
+    });
+
   });
 
-  it('should insert shim when sticking content', function(){
-    expect($('.shim').length).toBe(0);
-    GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
-    expect($('.shim').length).toBe(1);
+  describe('for larger screens (>768px)', function(){
+
+    beforeEach(function() {
+      GOVUK.stickAtTopWhenScrolling.getWindowPositions = function(){
+        return {
+          scrollTop: 300
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.getElementOffset = function(){
+        return {
+          top: 300
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.getWindowDimensions = function(){
+        return {
+          height: 768,
+          width: 769
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.$els = $stickyElement;
+      GOVUK.stickAtTopWhenScrolling._hasScrolled = true;
+      GOVUK.stickAtTopWhenScrolling.checkScroll();
+    });
+
+    it('should stick, if the scroll position is past the element position', function(){
+      expect($stickyElement.hasClass('content-fixed')).toBe(true);
+    });
+
+    it('should unstick, if the scroll position is less than the point at which scrolling started', function(){
+      GOVUK.stickAtTopWhenScrolling.getWindowPositions = function() {
+        return {
+          scrollTop: 0
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.$els = $stickyElement;
+      GOVUK.stickAtTopWhenScrolling._hasScrolled = true;
+      GOVUK.stickAtTopWhenScrolling.checkScroll();
+      expect($stickyElement.hasClass('content-fixed')).toBe(false);
+    });
+
   });
 
-  it('should insert shim with minimum height', function(){
-    GOVUK.stickAtTopWhenScrolling.stick($stickyElement);
-    expect($('.shim').height()).toBe(1);
+  describe('for smaller screens (<=768px)', function(){
+
+    beforeEach(function() {
+      GOVUK.stickAtTopWhenScrolling.getWindowDimensions = function() {
+        return {
+          height: 768,
+          width: 767
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.getElementOffset = function() {
+        return {
+          top: 300
+        };
+      };
+      GOVUK.stickAtTopWhenScrolling.$els = $stickyElement;
+      GOVUK.stickAtTopWhenScrolling._hasScrolled = true;
+      GOVUK.stickAtTopWhenScrolling.checkScroll();
+    });
+
+    it('should unstick the element', function(){
+      expect($stickyElement.hasClass('content-fixed')).toBe(false);
+    });
+
   });
+
 });
 


### PR DESCRIPTION
For smaller screens (<768px) ensure that the element which was previously "stuck" is "unstuck",  (removing both the class which sets fixed positioning and the shim).

This PR adds mocks for the window scroll position, offset of the sticky element and the window dimensions and updates stickAtTopWhenScrolling to use these.

It adds new tests to ensure that the three conditions of checkScroll are met, to "stick" or "unstick (release)" a sticky element.

Tests:

![screen shot 2016-09-20 at 17 57 03](https://cloud.githubusercontent.com/assets/417754/18680442/af15c33c-7f5b-11e6-8c11-a092c400d59e.png)
