### PR TITLE
Add semicolons to the start of each js file

### DIFF
--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}

--- a/javascripts/govuk/analytics/download-link-tracker.js
+++ b/javascripts/govuk/analytics/download-link-tracker.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/analytics/error-tracking.js
+++ b/javascripts/govuk/analytics/error-tracking.js
@@ -1,5 +1,5 @@
 // Extension to track errors using google analytics as a data store.
-(function (global) {
+;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}

--- a/javascripts/govuk/analytics/external-link-tracker.js
+++ b/javascripts/govuk/analytics/external-link-tracker.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}

--- a/javascripts/govuk/analytics/mailto-link-tracker.js
+++ b/javascripts/govuk/analytics/mailto-link-tracker.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/analytics/print-intent.js
+++ b/javascripts/govuk/analytics/print-intent.js
@@ -1,5 +1,5 @@
 // Extension to monitor attempts to print pages.
-(function (global) {
+;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}

--- a/javascripts/govuk/modules.js
+++ b/javascripts/govuk/modules.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/modules/auto-track-event.js
+++ b/javascripts/govuk/modules/auto-track-event.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}

--- a/javascripts/govuk/multivariate-test.js
+++ b/javascripts/govuk/multivariate-test.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/primary-links.js
+++ b/javascripts/govuk/primary-links.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -1,4 +1,4 @@
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/shim-links-with-button-role.js
+++ b/javascripts/govuk/shim-links-with-button-role.js
@@ -8,7 +8,7 @@
 // object with your own selector for the target elements and addional keyup
 // codes if there becomes a need to do so. For example:
 // GOVUK.shimLinksWithButtonRole.init({ selector: '[role="button"]' });
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/javascripts/govuk/stop-scrolling-at-footer.js
@@ -10,7 +10,7 @@
 // Height is passed in separatly incase the scrolling element has no height
 // itself.
 
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery

--- a/javascripts/stageprompt.js
+++ b/javascripts/stageprompt.js
@@ -21,7 +21,7 @@
 //
 //     <a class="help-button" href="#" data-journey-click="stage:help:info">See more info...</a>
 
-(function (global) {
+;(function (global) {
   'use strict'
 
   var $ = global.jQuery


### PR DESCRIPTION
Add a leading semicolon in front of immediately-invoked function
expressions, so that each file can be safely concatenated.