### PR TITLE
Update package.json to match npm package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "govuk_frontend_toolkit_test_runner",
+  "name": "govuk_frontend_toolkit",
   "repository": "https://github.com/alphagov/govuk_frontend_toolkit",
   "version": "0.1.0",
   "devDependencies": {


### PR DESCRIPTION
This repo is published to npm as `govuk_frontend_toolkit`.
>i.e. Installing via `npm install` creates the `govuk_frontend_toolkit` directory in `node_modules`.

The `name` field in **package.json** is wrongly set to `govuk_frontend_toolkit_test_runner`.
>i.e. Installing directly from a GitHub named branch creates the `govuk_frontend_toolkit_test_runner` directory in `node_modules`.


### Problem scenario
To test a potential pull request in an existing project, it's necessary to swap between the npm version (current) and a Git named-branch (work-in-progress pull request) via GitHub or elsewhere.

This creates a minor pain. Expect a fair few find & replace searches.

### Unknowns

1. Impact of updating `name` field to match what's already published on *npm*
2. Impact on future `npm upgrade` runs after the change

Can we discuss?

Thanks