### PR TITLE
Change colour used in phase tags to govuk-blue

### DIFF
--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -534,16 +534,12 @@ A mixin to create a GOV.UK Phase banner, with alpha/beta tag inside.
 
 #### Description
 
-`@mixin phase-banner($state)`
-
-`$state` is either `alpha` or `beta`.
-
-`$state` sets the background colour of the phase tag to the appropriate alpha or beta colour.
+`@mixin phase-banner()`
 
 ##### Phase banner - Alpha
 
     .phase-banner  {
-      @include phase-banner(alpha);
+      @include phase-banner();
     }
 
     <div class="phase-banner">
@@ -556,7 +552,7 @@ A mixin to create a GOV.UK Phase banner, with alpha/beta tag inside.
 ##### Phase banner - Beta
 
     .phase-banner  {
-      @include phase-banner(beta);
+      @include phase-banner();
     }
 
     <div class="phase-banner">
@@ -572,16 +568,12 @@ A mixin to create an alpha/beta tag.
 
 #### Description
 
-`@mixin phase-tag($state)`
-
-`$state` is either `alpha` or `beta`.
-
-`$state` sets the background colour of the phase tag to the appropriate alpha or beta colour.
+`@mixin phase-tag()`
 
 ##### Phase tag - Alpha
 
     .alpha-tag{
-      @include phase-tag(alpha);
+      @include phase-tag();
     }
     <h2>
       Apply using the new service <span class="alpha-tag">ALPHA</span>
@@ -590,7 +582,7 @@ A mixin to create an alpha/beta tag.
 ##### Phase tag - Beta
 
     .beta-tag{
-      @include phase-tag(beta);
+      @include phase-tag();
     }
     <h2>
       Apply using the new service <span class="beta-tag">BETA</span>

--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -6,10 +6,15 @@
 // Phase banner usage:
 //
 // .phase-banner {
-//    @include phase-banner($state: beta);
+//    @include phase-banner();
 // }
 
-@mixin phase-banner($state: alpha) {
+@mixin phase-banner($state: '') {
+
+  @if $state != '' {
+    @warn 'Passing a phase to the alpha/beta banners is deprecated';
+  }
+
   padding: 10px 0 8px;
 
   @include media(tablet) {
@@ -26,7 +31,7 @@
   }
 
   .phase-tag {
-    @include phase-tag($state);
+    @include phase-tag();
   }
 
   span {
@@ -37,17 +42,17 @@
 
 // Phase tag usage:
 //
-// Alpha
+// Alpha or beta
 // .phase-tag {
 //    @include phase-tag;
 // }
-//
-// Beta
-// .phase-tag {
-//    @include phase-tag(beta);
-// }
 
-@mixin phase-tag($state: alpha) {
+@mixin phase-tag($state: '') {
+
+  @if $state != '' {
+    @warn 'Passing a phase to the phase-tag mixin is deprecated';
+  }
+
   @include inline-block;
   margin: 0 8px 0 0;
   padding: 2px 5px 0;
@@ -58,9 +63,5 @@
   text-decoration: none;
 
   color: $white;
-  @if $state == alpha {
-    background-color: $alpha-colour;
-  } @else if $state == beta {
-    background-color: $beta-colour;
-  }
+  background-color: $govuk-blue;
 }


### PR DESCRIPTION
## Summary
This pr changes the background colour used in the phase tags to $govuk-blue rather than $alpha-colour or $beta-colour which have insufficient contrast.

The current pink has a contrast of 4.46:1 (nearly ok), but the orange is 2.78:1.

Have discussed with accessibility team and @timpaul but will want to discuss with the rest of the design team.

Ideally I'd use a semantic sass name, but I believe $mainstream-brand may change per org, which is not what we want here.

Prints a sass warning to let users know passing a phase tag is depreciated.

Before:
![screen shot 2016-11-24 at 18 06 58](https://cloud.githubusercontent.com/assets/2204224/20607510/f0b30050-b270-11e6-82a0-cd4725d9f140.png)
![screen shot 2016-11-24 at 18 07 03](https://cloud.githubusercontent.com/assets/2204224/20607514/f42fad82-b270-11e6-8910-c197a7d281a9.png)

After:
![screen shot 2016-11-24 at 18 07 24](https://cloud.githubusercontent.com/assets/2204224/20607517/facc6ee6-b270-11e6-8288-d4aaeac46f50.png)
![screen shot 2016-11-24 at 18 07 37](https://cloud.githubusercontent.com/assets/2204224/20607520/fe1b72d6-b270-11e6-8e42-3cc68a099310.png)

## Why not adjust to darker colours?

The pink can be adjusted (will do regardless in a separate pr), but there's no way of getting the orange to meet contrast checks without being brown or red. 

Separately - there's no real reason for them to have different colours - users don't know what alpha or beta mean, let alone the colours. Changing them to blue makes the pages more consistent.

## Why not remove the banners entirely?

Is a possible solution, but will need much more discussion. This is an easier change to do - whilst any other discussion about keeping or removing the banners happens.

## Testing

These changes haven't been tested - am unsure how to test frontend toolkit changes.

## Still to do / oustanding:
* need to update elements / other bits of GOV.UK that use the phase banner.