### PR TITLE
setInitialState supports both string and jQuery

### DIFF
--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -16,7 +16,7 @@
     }
     if (typeof elmsOrSelector === 'string') {
       this.selector = elmsOrSelector
-      this.setInitialState($(this.selector))
+      this.setInitialState(this.selector)
     } else if (elmsOrSelector !== undefined) {
       this.$elms = elmsOrSelector
       this.setInitialState(this.$elms)
@@ -30,7 +30,9 @@
       this.addDocumentLevelEvents()
     }
   }
-  SelectionButtons.prototype.setInitialState = function ($elms) {
+  SelectionButtons.prototype.setInitialState = function (elmsOrSelector) {
+    var $elms = elmsOrSelector instanceof $ ? elmsOrSelector : $(elmsOrSelector)
+
     $elms.each(function (idx, elm) {
       var $elm = $(elm)
 


### PR DESCRIPTION
fixes #355

setInitialState only accepted jQuery object so if you
passed a string of selectors it would break. My changes
tests if the parameter value is an instance of
jQuery and if it is not then it attempts to convert it
to one by calling $();