### PR TITLE
Allow tablet, desktop breakpoints to be overridden

### DIFF
--- a/stylesheets/_conditionals.scss
+++ b/stylesheets/_conditionals.scss
@@ -25,6 +25,9 @@
 $is-ie: false !default;
 $mobile-ie6: true !default;
 
+$tablet-breakpoint: 641px !default;
+$desktop-breakpoint: 769px !default;
+
 @mixin media($size: false, $max-width: false, $min-width: false, $ignore-for-ie: false) {
   @if $is-ie and ($ignore-for-ie == false) {
     @if $size != mobile {
@@ -34,15 +37,15 @@ $mobile-ie6: true !default;
     }
   } @else {
     @if $size == desktop {
-      @media (min-width: 769px){
+      @media (min-width: $desktop-breakpoint){
         @content;
       }
     } @else if $size == tablet {
-      @media (min-width: 641px){
+      @media (min-width: $tablet-breakpoint){
         @content;
       }
     } @else if $size == mobile {
-      @media (max-width: 640px){
+      @media (max-width: $tablet-breakpoint - 1px){
         @content;
       }
     } @else if $max-width != false {


### PR DESCRIPTION
We are using GOV.UK Frontend Toolkit in the tech docs work we are doing (although it’s currently just vendor’ed in) and need to override the breakpoints used by the `media` mixin so that the behaviour makes sense for our application.

This makes the tablet and desktop breakpoints variables with default values, which can be overriden by e.g. specifying different values in the application’s stylesheet before frontend toolkit is included.