### PR TITLE
Trigger focus-on-click for Firefox [DISCUSS BEFORE MERGE]

### DIFF
--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -83,7 +83,9 @@
   }
   SelectionButtons.prototype.getClickHandler = function () {
     return function (e) {
-      this.markSelected($(e.target))
+      var target = $(e.target)
+      this.markSelected(target)
+      target.trigger('focus')
     }.bind(this)
   }
   SelectionButtons.prototype.getFocusHandler = function (opts) {


### PR DESCRIPTION
When a user clicks on an unselected radio button in Chrome it’ll fire two events: `click` and either `focus` or `focusin` depending on delegation status. In Firefox only the `click` event fires. Tabbing through the fields triggers the focus events properly in both browsers.

We’re relying on the `focus`/`focusin` events to set the `focused` class that the yellow outline hooks onto. If we want consistency in this visual behaviour between browsers we either need to find some other way of defining the class, or to trigger the focus state on click dynamically. This commit does the second.

I think Firefox is technically in the wrong here according to the DOM 3 Events spec. At the end of the [current click event section](https://www.w3.org/TR/2016/WD-uievents-20160804/#event-type-click) is this sentence:

> If the event target is focusable, the default action MUST be to give that element document focus.

I’ll file a bug.