### PR TITLE
[DO NOT MERGE] Add tracker to track clicks on breadcrumb links

### DIFF
--- a/javascripts/govuk/analytics/breadcrumb-link-tracker.js
+++ b/javascripts/govuk/analytics/breadcrumb-link-tracker.js
@@ -1,0 +1,50 @@
+;(function (global) {
+  'use strict'
+
+  var $ = global.jQuery
+  var GOVUK = global.GOVUK || {}
+
+  GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {}
+  GOVUK.analyticsPlugins.breadcrumbLinkTracker = function (options) {
+    options = options || {}
+    var breadcrumbLinkSelector = options.selector
+
+    if (breadcrumbLinkSelector) {
+      $('body').on('click', breadcrumbLinkSelector, trackBreadcrumbClick)
+    }
+
+    function trackBreadcrumbClick (evt) {
+      var linkPosition = $(breadcrumbLinkSelector).index(this)
+      var $link = getLinkFromEvent(evt)
+      var href = $link.attr('href')
+      var linkText = $.trim($link.text())
+      var currentPath = $(global).attr('location').pathname
+      var evtOptions = {
+        page: currentPath,
+        label: href,
+        transport: 'beacon'
+      }
+
+      // Set the link text as a dimension
+      // TODO: we need to speak with performance analysts in order to determine
+      // what the value should be. For now, it's fake.
+      var titleDimension = 12345
+      GOVUK.analytics.setDimension(titleDimension, linkText)
+
+      // Custom event for click tracking
+      GOVUK.analytics.trackEvent('breadcrumbClicked', linkPosition, evtOptions)
+    }
+
+    function getLinkFromEvent (evt) {
+      var $target = $(evt.target)
+
+      if (!$target.is('a')) {
+        $target = $target.parents('a')
+      }
+
+      return $target
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/spec/unit/analytics/breadcrumb-link-tracker.spec.js
+++ b/spec/unit/analytics/breadcrumb-link-tracker.spec.js
@@ -1,0 +1,88 @@
+/* global describe it expect beforeEach afterEach spyOn */
+
+var $ = window.jQuery
+
+describe('GOVUK.analyticsPlugins.breadcrumbLinkTracker', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  var $links
+
+  beforeEach(function () {
+    $links = $(
+      '<div class="govuk-breadcrumbs">' +
+        '<ol>' +
+          '<li>' +
+              '<a href="/">Home</a>' +
+          '</li>' +
+          '<li>' +
+              '<a href="/browse/benefits">Benefits</a>' +
+          '</li>' +
+          '<li>' +
+              '<a href="/browse/benefits/entitlement">Benefits entitlement</a>' +
+          '</li>' +
+        '</ol>' +
+      '</div>' +
+      '<div class="other-links">' +
+        '<a href="/another-link">Another link</a>' +
+      '</div>'
+    )
+
+    $('html').on('click', function (evt) { evt.preventDefault() })
+    $('body').append($links)
+    GOVUK.analytics = {
+      setDimension: function () {},
+      trackEvent: function () {}
+    }
+    GOVUK.analyticsPlugins.breadcrumbLinkTracker({selector: '.govuk-breadcrumbs a'})
+  })
+
+  afterEach(function () {
+    $('html').off()
+    $('body').off()
+    $links.remove()
+    delete GOVUK.analytics
+  })
+
+  it('listens to clicks on links that match the selector', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(GOVUK.analytics, 'setDimension')
+
+    $('.govuk-breadcrumbs a').each(function () {
+      $(this).trigger('click')
+      expect(GOVUK.analytics.setDimension).toHaveBeenCalled()
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalled()
+      GOVUK.analytics.trackEvent.calls.reset()
+      GOVUK.analytics.setDimension.calls.reset()
+    })
+
+    $('.other-links a').each(function () {
+      $(this).trigger('click')
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled()
+      GOVUK.analytics.trackEvent.calls.reset()
+    })
+  })
+
+  it('sets the dimension with the link text and sends a track event', function() {
+    spyOn(GOVUK.analytics, 'trackEvent')
+    spyOn(GOVUK.analytics, 'setDimension')
+    spyOn(window.location.pathname, '/benefit-cap'
+
+    var homeLink = $('.govuk-breadcrumbs a').first()
+    homeLink.trigger('click')
+
+    expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(12345, 'Home')
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'breadcrumbClicked',
+      1,
+      {
+        page: '/benefit-cap',
+        label: '/',
+        transport: 'beacon'
+      }
+    )
+
+    GOVUK.analytics.trackEvent.calls.reset()
+    GOVUK.analytics.setDimension.calls.reset()
+  })
+})


### PR DESCRIPTION
For review only, this still needs validation from performance analysts so we know it's doing the expected behaviour.

------

This new tracker will track clicks on breadcrumb links and collect the
following information in a custom event:

- The event category: `breadcrumbClicked`;
- The action: the position of the link in the breadcrumbs (e.g. 2);
- The label: the href to which the link points to (e.g. `/browse/benefits/entitlement`);
- The link text as a custom dimension (e.g. `Benefits entitlement`).

The custom dimension is set prior to calling the `trackEvent` function, so it's sent in that event.

**NOTE**: the custom dimension value is still undetermined, the existing
one is a placeholder and needs to be replaced before this goes live.

Trello:
https://trello.com/c/buYUPz1l/247-enable-tracking-of-breadcrumb-clicks-across-applications-rendering-education-content