### PR TITLE
Run tests against jQuery 1.12.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jasmine": "^1.0.0",
     "grunt-contrib-sass": "0.7.4",
-    "jquery": "~1.11.3",
+    "jquery": "~1.12.4",
     "standard": "^8.2.0"
   },
   "scripts": {


### PR DESCRIPTION
Keep toolkit up to date with the latest 1.X jQuery release.

See also:
https://github.com/alphagov/static/pull/869

Release notes:
https://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/
https://blog.jquery.com/2016/02/22/jquery-1-12-1-and-2-2-1-released/
https://blog.jquery.com/2016/03/17/jquery-1-12-2-and-2-2-2-released/
https://blog.jquery.com/2016/04/05/jquery-1-12-3-and-2-2-3-released/
https://blog.jquery.com/2016/05/20/jquery-1-12-4-and-2-2-4-released/