### PR TITLE
Allow tracking of custom dimensions

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -102,7 +102,26 @@
       evt.transport = options.transport
     }
 
+    // Find any custom dimensions being set in the options, and pass them to GA
+    // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
+    var customDimensions = getCustomDimensions(options)
+    if (customDimensions && Object.keys(customDimensions).length) {
+      Object.assign(evt, customDimensions)
+    }
+
     sendToGa('send', evt)
+
+    function getCustomDimensions(options) {
+      var dimensionMatcher = /^dimension[0-9]+$/
+      return Object.keys(options)
+        .filter(function (key) {
+          return dimensionMatcher.test(key)
+        })
+        .reduce(function (dimensions, customDimensionKey) {
+          dimensions[customDimensionKey] = options[customDimensionKey]
+          return dimensions
+        }, {})
+    }
   }
 
   /*

--- a/javascripts/vendor/polyfills/array/filter.js
+++ b/javascripts/vendor/polyfills/array/filter.js
@@ -1,0 +1,47 @@
+// Array.prototype.filter
+//
+// The filter() method creates a new array with all elements that pass the test implemented by the provided function.
+//
+// Array.filter is natively supported in:
+//   Chrome (all)
+//   Firefox 1.5+
+//   IE 9+
+//   Opera (all)
+//   Safari (all)
+//
+// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+
+if (!Array.prototype.filter) {
+  Array.prototype.filter = function(fun/*, thisArg*/) {
+    'use strict';
+
+    if (this === void 0 || this === null) {
+      throw new TypeError();
+    }
+
+    var t = Object(this);
+    var len = t.length >>> 0;
+    if (typeof fun !== 'function') {
+      throw new TypeError();
+    }
+
+    var res = [];
+    var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+    for (var i = 0; i < len; i++) {
+      if (i in t) {
+        var val = t[i];
+
+        // NOTE: Technically this should Object.defineProperty at
+        //       the next index, as push can be affected by
+        //       properties on Object.prototype and Array.prototype.
+        //       But that method's new, and collisions should be
+        //       rare, so use the more-compatible alternative.
+        if (fun.call(thisArg, val, i, t)) {
+          res.push(val);
+        }
+      }
+    }
+
+    return res;
+  };
+}

--- a/javascripts/vendor/polyfills/array/reduce.js
+++ b/javascripts/vendor/polyfills/array/reduce.js
@@ -1,0 +1,71 @@
+// Array.prototype.filter
+//
+// The reduce() method applies a function against an accumulator and each value of the array (from left-to-right)
+// to reduce it to a single value.
+//
+// Array.reduce is natively supported in:
+//   Chrome (all)
+//   Firefox 3+
+//   IE 9+
+//   Opera 10.5+
+//   Safari 4+
+//
+// https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
+
+// Production steps of ECMA-262, Edition 5, 15.4.4.21
+// Reference: http://es5.github.io/#x15.4.4.21
+// https://tc39.github.io/ecma262/#sec-array.prototype.reduce
+if (!Array.prototype.reduce) {
+  Object.defineProperty(Array.prototype, 'reduce', {
+    value: function(callback /*, initialValue*/) {
+      if (this === null) {
+        throw new TypeError('Array.prototype.reduce called on null or undefined');
+      }
+      if (typeof callback !== 'function') {
+        throw new TypeError(callback + ' is not a function');
+      }
+
+      // 1. Let O be ? ToObject(this value).
+      var o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+
+      // Steps 3, 4, 5, 6, 7
+      var k = 0;
+      var value;
+
+      if (arguments.length == 2) {
+        value = arguments[1];
+      } else {
+        while (k < len && !(k in o)) {
+          k++;
+        }
+
+        // 3. If len is 0 and initialValue is not present, throw a TypeError exception.
+        if (k >= len) {
+          throw new TypeError('Reduce of empty array with no initial value');
+        }
+        value = o[k++];
+      }
+
+      // 8. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kPresent be ? HasProperty(O, Pk).
+        // c. If kPresent is true, then
+        //    i. Let kValue be ? Get(O, Pk).
+        //    ii. Let accumulator be ? Call(callbackfn, undefined, « accumulator, kValue, k, O »).
+        if (k in o) {
+          value = callback(value, o[k], k, o);
+        }
+
+        // d. Increase k by 1.
+        k++;
+      }
+
+      // 9. Return accumulator.
+      return value;
+    }
+  });
+}

--- a/javascripts/vendor/polyfills/object/assign.js
+++ b/javascripts/vendor/polyfills/object/assign.js
@@ -1,0 +1,37 @@
+// Object.prototype.assign
+//
+// The Object.assign() method is used to copy the values of all enumerable own properties from one or more source
+// objects to a target object. It will return the target object.
+//
+// Object.assign is natively supported in:
+//   Chrome 45+
+//   Firefox 34+
+//   Opera 32+
+//   Safari 9+
+//
+// Originally from: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+
+if (typeof Object.assign != 'function') {
+  Object.assign = function (target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}

--- a/javascripts/vendor/polyfills/object/keys.js
+++ b/javascripts/vendor/polyfills/object/keys.js
@@ -1,0 +1,55 @@
+// Object.prototype.keys
+//
+// The Object.keys() method returns an array of a given object's own enumerable properties, in the same order as that
+// provided by a for...in loop (the difference being that a for-in loop enumerates properties in the prototype chain
+// as well).
+//
+// Object.keys is natively supported in:
+//   Chrome 5+
+//   Firefox 4+
+//   IE 9+
+//   Opera 12+
+//   Safari 5+
+//
+// Originally from: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+
+if (!Object.keys) {
+  Object.keys = (function() {
+    'use strict';
+    var hasOwnProperty = Object.prototype.hasOwnProperty,
+      hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
+      dontEnums = [
+        'toString',
+        'toLocaleString',
+        'valueOf',
+        'hasOwnProperty',
+        'isPrototypeOf',
+        'propertyIsEnumerable',
+        'constructor'
+      ],
+      dontEnumsLength = dontEnums.length;
+
+    return function(obj) {
+      if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
+        throw new TypeError('Object.keys called on non-object');
+      }
+
+      var result = [], prop, i;
+
+      for (prop in obj) {
+        if (hasOwnProperty.call(obj, prop)) {
+          result.push(prop);
+        }
+      }
+
+      if (hasDontEnumBug) {
+        for (i = 0; i < dontEnumsLength; i++) {
+          if (hasOwnProperty.call(obj, dontEnums[i])) {
+            result.push(dontEnums[i]);
+          }
+        }
+      }
+      return result;
+    };
+  }());
+}

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -145,6 +145,13 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
         ['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action', transport: 'beacon'}]
       )
     })
+
+    it('tracks custom dimensions', function() {
+      universal.trackEvent('category', 'action', {dimension29: 'Home'})
+      expect(window.ga.calls.mostRecent().args).toEqual(
+        ['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action', dimension29: 'Home'}]
+      )
+    })
   })
 
   describe('when social events are tracked', function () {


### PR DESCRIPTION
Enable the tracking of Google Analytics custom dimensions, as required by this pull request: https://github.com/alphagov/static/pull/875

I've also added some polyfills for "common" (ie useful) `Array` and `Object` functions.