### PR TITLE
Allow custom options when tracking events

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -102,7 +102,26 @@
       evt.transport = options.transport
     }
 
+    var customDimensions = getCustomDimensions(options)
+    if (customDimensions) {
+      $.extend(evt, customDimensions)
+    }
+
     sendToGa('send', evt)
+
+    function getCustomDimensions(options) {
+      var customDimensionMatcher = /^dimension[0-9]+$/;
+      var customDimensions = null
+
+      $.each(options, function(key, value) {
+        if (customDimensionMatcher.test(key)) {
+          customDimensions = customDimensions || {}
+          customDimensions[key] = value
+        }
+      })
+
+      return customDimensions
+    }
   }
 
   /*

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -72,11 +72,7 @@
     // Label is optional
     if (typeof options.label === 'string') {
       evt.eventLabel = options.label
-    }
-
-    // Page is optional
-    if (typeof options.page === 'string') {
-      evt.page = options.page
+      delete options.label
     }
 
     // Value is optional, but when used must be an
@@ -85,43 +81,22 @@
     if (options.value || options.value === 0) {
       value = parseInt(options.value, 10)
       if (typeof value === 'number' && !isNaN(value)) {
-        evt.eventValue = value
+        options.eventValue = value
       }
+      delete options.value
     }
 
     // Prevents an event from affecting bounce rate
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#implementation
     if (options.nonInteraction) {
-      evt.nonInteraction = 1
+      options.nonInteraction = 1
     }
 
-    // Set the transport method for the event
-    // Typically used for enabling `navigator.sendBeacon` when the page might be unloading
-    // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
-    if (options.transport) {
-      evt.transport = options.transport
-    }
-
-    var customDimensions = getCustomDimensions(options)
-    if (customDimensions) {
-      $.extend(evt, customDimensions)
+    if (typeof options === 'object') {
+      $.extend(evt, options)
     }
 
     sendToGa('send', evt)
-
-    function getCustomDimensions(options) {
-      var customDimensionMatcher = /^dimension[0-9]+$/;
-      var customDimensions = null
-
-      $.each(options, function(key, value) {
-        if (customDimensionMatcher.test(key)) {
-          customDimensions = customDimensions || {}
-          customDimensions[key] = value
-        }
-      })
-
-      return customDimensions
-    }
   }
 
   /*

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -100,6 +100,13 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       )
     })
 
+    it('tracks custom dimensions', function() {
+      universal.trackEvent('category', 'action', {dimension29: 'Home'})
+      expect(window.ga.calls.mostRecent().args).toEqual(
+        ['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action', dimension29: 'Home'}]
+      )
+    })
+
     it('the label is optional', function () {
       universal.trackEvent('category', 'action')
       expect(window.ga.calls.mostRecent().args).toEqual(


### PR DESCRIPTION
Adding the ability to track custom dimensions so that we can define them in the `options` object, and perform calls like `GOVUK.analytics.trackEvent('category', 'action', {dimension29: 'dimensionValue'});`

This is required by markups suggested here: https://github.com/alphagov/static/pull/875#pullrequestreview-15881444