### PR TITLE
Improve colour contrast of DEFRA & HMRC text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Development
+
+- Change HMRC and DEFRA text colours for improved contrast
+
 # 5.0.2
 
 - Change colour used in phase tags to govuk-blue ([PR #353](https://github.com/alphagov/govuk_frontend_toolkit/pull/353))

--- a/stylesheets/colours/_organisation.scss
+++ b/stylesheets/colours/_organisation.scss
@@ -16,6 +16,7 @@ $department-for-culture-media-sport-websafe: #a03155;
 $department-for-education: #003a69;
 $department-for-education-websafe: #347ca9;
 $department-for-environment-food-rural-affairs: #00a33b;
+$department-for-environment-food-rural-affairs-websafe: #008938;
 $department-for-international-development: #002878;
 $department-for-international-development-websafe: #405e9a;
 $department-for-international-trade: #CF102D;
@@ -34,7 +35,7 @@ $government-equalities-office: #9325b2;
 $hm-government: #0076c0;
 $hm-government-websafe: #347da4;
 $hm-revenue-customs: #009390;
-$hm-revenue-customs-websafe: #008770;
+$hm-revenue-customs-websafe: #008670;
 $hm-treasury: #af292e;
 $hm-treasury-websafe: #832322;
 $home-office: #9325b2;
@@ -79,7 +80,7 @@ $all-organisation-brand-colours:
   'department-for-communities-and-local-government' $department-for-communities-and-local-government $department-for-communities-and-local-government-websafe,
   'department-for-culture-media-sport' $department-for-culture-media-sport $department-for-culture-media-sport-websafe,
   'department-for-education' $department-for-education $department-for-education-websafe,
-  'department-for-environment-food-rural-affairs' $department-for-environment-food-rural-affairs $department-for-environment-food-rural-affairs,
+  'department-for-environment-food-rural-affairs' $department-for-environment-food-rural-affairs $department-for-environment-food-rural-affairs-websafe,
   'department-for-international-development' $department-for-international-development $department-for-international-development-websafe,
   'department-for-international-trade' $department-for-international-trade $department-for-international-trade-websafe,
   'department-for-transport' $department-for-transport $department-for-transport-websafe,


### PR DESCRIPTION
Make sure text colour meets the contrast ratio 4.5:1 to meet WCAG AA standard.

> HMRC: #008670 (contrast 4.52:1 from 4.47:1)
> DEFRA: #008938 (contrast 4.53:1 from 3.37:1)

https://www.w3.org/TR/WCAG20/#larger-scaledef

Fixes https://github.com/alphagov/govuk_frontend_toolkit/issues/316

https://trello.com/c/4QPPRvuy/558-make-sure-all-organisation-colours-are-accessible

cc @edwardhorsford 