### PR TITLE
For discussion: Make alpha, beta and discovery colours $govuk-blue

### DIFF
--- a/stylesheets/colours/_palette.scss
+++ b/stylesheets/colours/_palette.scss
@@ -68,9 +68,9 @@ $panel-colour: $grey-3;           // Related links panel, page footer etc.
 $canvas-colour: $grey-4;          // Page background
 $highlight-colour: $grey-4;       // Table stripes etc.
 $page-colour: $white;             // The page
-$discovery-colour: $fuschia;      // Discovery badges and banners
-$alpha-colour: $pink;             // Alpha badges and banners
-$beta-colour: $orange;            // Beta badges and banners
+$discovery-colour: $govuk-blue;   // Discovery badges and banners
+$alpha-colour: $govuk-blue;       // Alpha badges and banners
+$beta-colour: $govuk-blue;        // Beta badges and banners
 $live-colour: $grass-green;       // Live badges and banners
 $banner-text-colour: #000;        // Text colour for Alpha & Beta banners
 $error-colour: $red;              // Error text and border colour


### PR DESCRIPTION
The phase tag is now $govuk-blue (as previously the pink and orange
colours used failed contrast requirements).

Do we want to update the Sass variables for $alpha-colour, $beta-colour and $discovery-colour to also use $govuk-blue?

Opened as this related issue was raised with the service manual: https://github.com/gds-attic/government-service-design-manual/issues/671
