### PR TITLE
Add colour contrast test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
 .sass-cache
 npm-debug.log
-spec/stylesheets
+spec/stylesheets/test*
 _SpecRunner.html

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,6 +16,8 @@ module.exports = function (grunt) {
     }
   )
 
+  allSassFiles.push("@import '_colour_contrast_spec.scss';")
+
   grunt.file.write(
     './spec/stylesheets/test.scss',
     allSassFiles.join('\n')
@@ -46,7 +48,9 @@ module.exports = function (grunt) {
         },
         options: {
           loadPath: [
-            './stylesheets'
+            './node_modules',
+            './stylesheets',
+            './spec/stylesheets'
           ],
           style: 'nested'
         }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "grunt-contrib-jasmine": "^1.0.0",
     "grunt-contrib-sass": "0.7.4",
     "jquery": "~1.12.4",
-    "standard": "^8.2.0"
+    "standard": "^8.2.0",
+    "sass-color-helpers": "^2.0.3"
   },
   "scripts": {
     "test": "grunt test && npm run lint --silent",

--- a/spec/stylesheets/_colour_contrast_spec.scss
+++ b/spec/stylesheets/_colour_contrast_spec.scss
@@ -1,0 +1,12 @@
+@import "colours/organisation";
+@import "sass-color-helpers/stylesheets/color-helpers/math";
+@import "sass-color-helpers/stylesheets/color-helpers/contrast";
+
+@each $organisation in $all-organisation-brand-colours {
+  $minimum-contrast: 4.5;
+  $contrast: ch-color-contrast($white, nth($organisation, 3));
+
+  @if ($contrast < $minimum-contrast) {
+    @error "Contrast ratio for #{nth($organisation, 1)} too low. #{nth($organisation, 3)} on #{$white} has a contrast of: #{$contrast}. Must be higher than #{$minimum-contrast} for WCAG AA support";
+  }
+}


### PR DESCRIPTION
Test that all organisation colours have a contrast ratio of 4.5 or greater against white. Error when contrast too low.

* Protects against poor colour choices in future
* Use sass-color-helpers to provide contrast function
  https://github.com/voxpelli/sass-color-helpers
* Only include colour helpers when in dev, don't package with gem
* Store sass test in same directory as generated sass test file
* Confirms that all current colours have good contrast ratio
* Confirms that old DEFRA colour was poor contrast ratio

Fixes #316

Example failing test:
https://travis-ci.org/alphagov/govuk_frontend_toolkit/builds/193155272

```
Error: Contrast ratio for department-for-environment-food-rural-affairs too low.
#00a33b on #fff has a contrast of: 3.3. Must be higher than 4.5 for WCAG AA support
        on line 10 of spec/stylesheets/_colour_contrast_spec.scss
        from line 18 of ./spec/stylesheets/test.scss
```

cc @robinwhittleton @nickcolley @edwardhorsford 

Thanks to @voxpelli for making this easy!
