### PR TITLE
Fix a weird stick at top when scrolling bug

### DIFF
--- a/javascripts/govuk/stick-at-top-when-scrolling.js
+++ b/javascripts/govuk/stick-at-top-when-scrolling.js
@@ -110,8 +110,9 @@
       if (!$el.hasClass('content-fixed')) {
         $el.data('scrolled-from', sticky.getElementOffset($el).top)
         var height = Math.max($el.height(), 1)
-        $el.before('<div class="shim" style="width: ' + $el.width() + 'px; height: ' + height + 'px">&nbsp;</div>')
-        $el.css('width', $el.width() + 'px').addClass('content-fixed')
+        var width = $el.width()
+        $el.before('<div class="shim" style="width: ' + width + 'px; height: ' + height + 'px">&nbsp;</div>')
+        $el.css('width', width + 'px').addClass('content-fixed')
       }
     },
     release: function ($el) {


### PR DESCRIPTION
For _reasons unknown_, getting the width of the 'stuck' element by calling `$el.width()` _after_ adding the shim to the document causes Chrome 56 to scroll down by the height of the shim, effectively ‘jumping’ the user down the document. This happens even if you just e.g. call `console.log($el.width)` without using the returned value.

This behaviour does not occur in other browsers, nor did it occur in Chrome 55.

Somehow, this fixes it.

¯\\_(ツ)_/¯

## Before
![before](https://cloud.githubusercontent.com/assets/121939/22432057/96db1232-e70b-11e6-98dc-c37743746f69.gif)

## After
![after](https://cloud.githubusercontent.com/assets/121939/22432063/9b20e1c8-e70b-11e6-8b85-992bd24c671e.gif)
