### PR TITLE
Fix unrecognisable buttons when changing colours

### DIFF
--- a/stylesheets/design-patterns/_buttons.scss
+++ b/stylesheets/design-patterns/_buttons.scss
@@ -30,6 +30,8 @@
   padding: .526315em .789473em .263157em; // 10px 15px 5px
   border: none;
   @include border-radius(0);
+  outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
+  outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
   -webkit-appearance: none;
 
   // Bottom edge effect


### PR DESCRIPTION
When overwriting colours via browser settings, Firefox always defaults buttons to a transparent background and IE defaults to a grey background, irrespective of said settings. When changing Windows system settings to a high contrast theme, Edge also defaults buttons to a transparent background.
That makes buttons appear just as normal text being a bit off kilter (due to the button padding).

To make them appear a bit more button-y again, this adds a transparent outline which is invisible in normal browser settings.

<del>The only slightly negative side effect I found during testing is that the buttons in Safari have lost their 3px focus outline and have a 1px focus outline instead. That could be fixed by changing the transparent outline to 3px but that made some other things worse again.</del>

Because Firefox always has black text on buttons, we actually have a completely invisible button on a dark background there. As far as I understand it, it's not fixable at all. I will file a bug report accordingly. Here is a reduced test case: http://jsbin.com/sibube

See also alphagov/govuk_elements#397.

## Screenshots (form buttons)

This is the page I was testing, showing the default colours:
![firefox-default](https://cloud.githubusercontent.com/assets/108893/22441540/c536f6ae-e72f-11e6-8701-2bf2bcabe498.png)

### Before

Firefox:
![firefox-light-before](https://cloud.githubusercontent.com/assets/108893/22441556/cea3c474-e72f-11e6-8d8d-c6394d29e1be.png)

IE 11:
![ie-light-before](https://cloud.githubusercontent.com/assets/108893/22441568/da76fdca-e72f-11e6-860a-f92200e77177.png)

Edge via changes in system settings:
<img width="528" alt="edge-dark-before" src="https://cloud.githubusercontent.com/assets/108893/22479872/468e948e-e7e7-11e6-85ef-a5207e9c1115.png">


### After

Firefox:
![firefox-light-after](https://cloud.githubusercontent.com/assets/108893/22441581/ea8b5882-e72f-11e6-89f8-e9cfb4ea286e.png)

IE 11:
<img width="424" alt="ie-light-after" src="https://cloud.githubusercontent.com/assets/108893/22441588/f19d28b2-e72f-11e6-967f-d465eecb6573.png">

Edge via changes in system settings:
<img width="527" alt="edge-dark-after" src="https://cloud.githubusercontent.com/assets/108893/22479883/56f5c0d6-e7e7-11e6-96d3-6c536fec0969.png">


## Screenshots (link buttons)

The original start now button with default colours:
![firefox-buttonlink-default](https://cloud.githubusercontent.com/assets/108893/22441621/19ae108c-e730-11e6-965b-bb1cc85bdd0f.png)

### Before

Firefox:
![firefox-buttonlink-light-before](https://cloud.githubusercontent.com/assets/108893/22441647/3376996c-e730-11e6-9141-d970e77e157e.png)
![firefox-buttonlink-dark-before](https://cloud.githubusercontent.com/assets/108893/22441651/365323da-e730-11e6-963f-3230639a8171.png)

IE 11:
<img width="153" alt="ie-buttonlink-light-before" src="https://cloud.githubusercontent.com/assets/108893/22441642/2bbe3bda-e730-11e6-8f34-2c03ca67f992.png">

### After

Firefox:

![firefox-buttonlink-light-after](https://cloud.githubusercontent.com/assets/108893/22441662/45182596-e730-11e6-8be0-1baaa0c13785.png)
![firefox-buttonlink-dark-after](https://cloud.githubusercontent.com/assets/108893/22441666/477cc044-e730-11e6-9ccb-737ed9092761.png)

IE 11:
<img width="151" alt="ie-buttonlink-light-after" src="https://cloud.githubusercontent.com/assets/108893/22441677/4e49a676-e730-11e6-8018-e2d4512462c7.png">
