### PR TITLE
Breadcrumb anchor link styling

### DIFF
--- a/stylesheets/design-patterns/_breadcrumbs.scss
+++ b/stylesheets/design-patterns/_breadcrumbs.scss
@@ -48,6 +48,11 @@
 
   a {
     color: $text-colour;
+
+    &[href^="#"] {
+      color: $secondary-text-colour;
+      text-decoration: none;
+    }
   }
 
 }


### PR DESCRIPTION
This style any breadcrumbs linking to anchors on the current page. This is used in conjunction with https://github.com/alphagov/govuk_navigation_helpers/pull/30 to show users which page they are currently on, when browsing the new taxonomy.

Before:
![govuk_frontend_toolkit-current-breadcrumb-before](https://cloud.githubusercontent.com/assets/12036746/22889355/ba6b697c-f200-11e6-86bb-c69a85b2c845.png)

After:
![govuk_frontend_toolkit-current-breadcrumb-after](https://cloud.githubusercontent.com/assets/12036746/22889392/de40c6e4-f200-11e6-9d77-bfd8dca4fbc4.png)

Trello: https://trello.com/c/MVM5bueS/386-add-current-page-to-taxonomy-breadcrumbs
