### PR TITLE
Add missing space before function parentheses.

### DIFF
--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -100,7 +100,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       )
     })
 
-    it('tracks custom dimensions', function() {
+    it('tracks custom dimensions', function () {
       universal.trackEvent('category', 'action', {dimension29: 'Home'})
       expect(window.ga.calls.mostRecent().args).toEqual(
         ['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action', dimension29: 'Home'}]


### PR DESCRIPTION
Ensure that all JS files use JavaScript Standard Style
(http://standardjs.com).

Running `npm test` locally resulted in this linter error. 
This should have been picked up by Travis.