### PR TITLE
Bump the version of Node used by Travis to the LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
+  - "6.9.5"
 before_install:
   - openssl aes-256-cbc -K $encrypted_909ac1036a94_key -iv $encrypted_909ac1036a94_iv -in .travis/govuk_frontend_toolkit_push.enc -out ~/.ssh/id_rsa -d
   - chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
https://nodejs.org/en/ - v6.9.5 is LTS.

Travis requires Node v4.0.0 or above to run standard.