### PR TITLE
Allow showing and hiding of multiple targets

### DIFF
--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -24,30 +24,48 @@
     function initToggledContent () {
       var $control = $(this)
       var $content = getToggledContent($control)
+      var contentIds = ''
 
       // Set aria-controls and defaults
       if ($content.length) {
-        $control.attr('aria-controls', $content.attr('id'))
+        $content.each(function () {
+          $(this).attr('aria-hidden', 'true')
+          contentIds += ' ' + $(this).attr('id')
+        })
+
+        $control.attr('aria-controls', contentIds.trim())
         $control.attr('aria-expanded', 'false')
-        $content.attr('aria-hidden', 'true')
       }
     }
 
     // Return toggled content for control
     function getToggledContent ($control) {
-      var id = $control.attr('aria-controls')
+      var targetIds = $control.attr('aria-controls')
 
       // ARIA attributes aren't set before init
-      if (!id) {
-        id = $control.closest('label').data('target')
+      if (!targetIds) {
+        targetIds = $control.closest('label').data('target')
+      }
+
+      // turn a space-separated list of ids into a comma-separated css id selector
+      // ie, 'id-1 id-2 id-3' becomes '#id-1, #id-2, #id-3'
+      if (targetIds) {
+        targetIds = targetIds
+                      .split(' ')
+                      .map(function (targetId) { return '#' + targetId })
+                      .join(', ')
       }
 
       // Find show/hide content by id
-      return $('#' + id)
+      return $(targetIds)
     }
 
     // Show toggled content for control
     function showToggledContent ($control, $content) {
+      if (!$content.length) {
+        return
+      }
+
       // Show content
       if ($content.hasClass('js-hidden')) {
         $content.removeClass('js-hidden')
@@ -63,6 +81,10 @@
     // Hide toggled content for control
     function hideToggledContent ($control, $content) {
       $content = $content || getToggledContent($control)
+
+      if (!$content.length) {
+        return
+      }
 
       // Hide content
       if (!$content.hasClass('js-hidden')) {

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -14,7 +14,7 @@ describe('show-hide-content', function () {
     this.$content.remove()
   })
 
-  describe('when the radios are inside a form', function () {
+  describe('when the controls are inside a form', function () {
     beforeEach(function () {
       // Sample markup
       this.$content = $(
@@ -249,7 +249,7 @@ describe('show-hide-content', function () {
     })
   })
 
-  describe('when the radios are outside of a form', function () {
+  describe('when the controls are outside of a form', function () {
     beforeEach(function () {
       // Sample markup
       this.$content = $(

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -96,8 +96,9 @@ describe('show-hide-content', function () {
       })
 
       it('should do nothing if no checkboxes are checked', function () {
-        expect(this.$radio1.attr('aria-expanded')).toBe('false')
-        expect(this.$radio2.attr('aria-expanded')).toBe(undefined)
+        expect(this.$checkbox1.attr('aria-expanded')).toBe('false')
+        expect(this.$checkbox2.attr('aria-expanded')).toBe(undefined)
+        expect(this.$checkbox3.attr('aria-expanded')).toBe(undefined)
       })
 
       describe('with non-default markup', function () {

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -250,6 +250,193 @@ describe('show-hide-content', function () {
     })
   })
 
+  describe('when the controls are inside a form and have multiple targets', function () {
+    beforeEach(function () {
+      // Sample markup
+      this.$content = $(
+
+        // Radio buttons (yes/no)
+        '<form>' +
+        '<label class="block-label" data-target="show-hide-radios-1 show-hide-radios-2">' +
+        '<input type="radio" name="single" value="yes">' +
+        'Yes' +
+        '</label>' +
+        '<label class="block-label">' +
+        '<input type="radio" name="single" value="no">' +
+        'No' +
+        '</label>' +
+        '<div id="show-hide-radios-1" class="panel js-hidden" />' +
+        '<div id="show-hide-radios-2" class="panel js-hidden" />' +
+        '</form>' +
+
+        // Checkboxes (multiple values)
+        '<form>' +
+        '<label class="block-label" data-target="show-hide-checkboxes-1 show-hide-checkboxes-2">' +
+        '<input type="checkbox" name="multiple[option1]">' +
+        'Option 1' +
+        '</label>' +
+        '<label class="block-label">' +
+        '<input type="checkbox" name="multiple[option2]">' +
+        'Option 2' +
+        '</label>' +
+        '<label class="block-label">' +
+        '<input type="checkbox" name="multiple[option3]">' +
+        'Option 3' +
+        '</label>' +
+        '<div id="show-hide-checkboxes-1" class="panel js-hidden" />' +
+        '<div id="show-hide-checkboxes-2" class="panel js-hidden" />' +
+        '</form>'
+      )
+
+      // Find radios/checkboxes
+      var $radios = this.$content.find('input[type=radio]')
+      var $checkboxes = this.$content.find('input[type=checkbox]')
+
+      // Two radios
+      this.$radio1 = $radios.eq(0)
+      this.$radio2 = $radios.eq(1)
+
+      // Three checkboxes
+      this.$checkbox1 = $checkboxes.eq(0)
+      this.$checkbox2 = $checkboxes.eq(1)
+      this.$checkbox3 = $checkboxes.eq(2)
+
+      // Add to page
+      $(document.body).append(this.$content)
+
+      // Show/Hide content
+      this.radiosShowHide = [$('#show-hide-radios-1'), $('#show-hide-radios-2')]
+      this.checkboxesShowHide = [$('#show-hide-checkboxes-1'), $('#show-hide-checkboxes-2')]
+
+      // Add show/hide content support
+      this.showHideContent = new GOVUK.ShowHideContent()
+      this.showHideContent.init()
+    })
+
+    describe('and when this.showHideContent = new GOVUK.ShowHideContent() is called', function () {
+      it('should add the aria attributes to inputs with show/hide content', function () {
+        expect(this.$radio1.attr('aria-expanded')).toBe('false')
+        expect(this.$radio1.attr('aria-controls')).toBe('show-hide-radios-1 show-hide-radios-2')
+      })
+
+      it('should add the aria attributes to show/hide content', function () {
+        this.radiosShowHide.forEach(function ($showHide) {
+          expect($showHide.attr('aria-hidden')).toBe('true')
+        })
+      })
+
+      it('should hide the show/hide content visually', function () {
+        this.radiosShowHide.forEach(function ($showHide) {
+          expect($showHide.hasClass('js-hidden')).toEqual(true)
+        })
+      })
+
+      describe('with non-default markup', function () {
+        beforeEach(function () {
+          this.showHideContent.destroy()
+        })
+
+        it('should make the show/hide content visible if its radio is checked', function () {
+          this.$radio1.prop('checked', true)
+
+          // Defaults changed, initialise again
+          this.showHideContent = new GOVUK.ShowHideContent().init()
+          expect(this.$radio1.attr('aria-expanded')).toBe('true')
+          this.radiosShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('false')
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+
+        it('should make the show/hide content visible if its checkbox is checked', function () {
+          this.$checkbox1.prop('checked', true)
+
+          // Defaults changed, initialise again
+          this.showHideContent = new GOVUK.ShowHideContent().init()
+          expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+          this.checkboxesShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('false')
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+      })
+
+      describe('and a show/hide radio receives a click', function () {
+        it('should make the show/hide content visible', function () {
+          this.$radio1.click()
+          this.radiosShowHide.forEach(function ($showHide) {
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+
+        it('should add the aria attributes to show/hide content', function () {
+          this.$radio1.click()
+          expect(this.$radio1.attr('aria-expanded')).toBe('true')
+          this.radiosShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('false')
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+      })
+
+      describe('and a show/hide checkbox receives a click', function () {
+        it('should make the show/hide content visible', function () {
+          this.$checkbox1.click()
+          this.checkboxesShowHide.forEach(function ($showHide) {
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+
+        it('should add the aria attributes to show/hide content', function () {
+          this.$checkbox1.click()
+          expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+          this.checkboxesShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('false')
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+      })
+
+      describe('and a show/hide radio receives a click, but another group radio is clicked afterwards', function () {
+        it('should make the show/hide content hidden', function () {
+          this.$radio1.click()
+          this.$radio2.click()
+          this.radiosShowHide.forEach(function ($showHide) {
+            expect($showHide.hasClass('js-hidden')).toEqual(true)
+          })
+        })
+
+        it('should add the aria attributes to show/hide content', function () {
+          this.$radio1.click()
+          this.$radio2.click()
+          expect(this.$radio1.attr('aria-expanded')).toBe('false')
+          this.radiosShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('true')
+          })
+        })
+      })
+
+      describe('and a show/hide checkbox receives a click, but another checkbox is clicked afterwards', function () {
+        it('should keep the show/hide content visible', function () {
+          this.$checkbox1.click()
+          this.$checkbox2.click()
+          this.checkboxesShowHide.forEach(function ($showHide) {
+            expect($showHide.hasClass('js-hidden')).toEqual(false)
+          })
+        })
+
+        it('should keep the aria attributes to show/hide content', function () {
+          this.$checkbox1.click()
+          this.$checkbox2.click()
+          expect(this.$checkbox1.attr('aria-expanded')).toBe('true')
+          this.checkboxesShowHide.forEach(function ($showHide) {
+            expect($showHide.attr('aria-hidden')).toBe('false')
+          })
+        })
+      })
+    })
+  })
+
   describe('when the controls are outside of a form', function () {
     beforeEach(function () {
       // Sample markup
@@ -302,6 +489,66 @@ describe('show-hide-content', function () {
       expect(this.$radio1.attr('aria-expanded')).toBe('false')
       expect(this.$radioShowHide.attr('aria-hidden')).toBe('true')
       expect(this.$radioShowHide.hasClass('js-hidden')).toEqual(true)
+    })
+  })
+
+  describe('when the controls are outside of a form and have multiple targets', function () {
+    beforeEach(function () {
+      // Sample markup
+      this.$content = $(
+        // Radio buttons (yes/no)
+        '<label class="block-label" data-target="show-hide-radios-1 show-hide-radios-2">' +
+        '<input type="radio" name="single" value="yes">' +
+        'Yes' +
+        '</label>' +
+        '<label class="block-label">' +
+        '<input type="radio" name="single" value="no">' +
+        'No' +
+        '</label>' +
+        '<div id="show-hide-radios-1" class="panel js-hidden" />' +
+        '<div id="show-hide-radios-2" class="panel js-hidden" />'
+      )
+
+      // Find radios/checkboxes
+      var $radios = this.$content.find('input[type=radio]')
+
+      // Two radios
+      this.$radio1 = $radios.eq(0)
+      this.$radio2 = $radios.eq(1)
+
+      // Add to page
+      $(document.body).append(this.$content)
+
+      // Show/Hide content
+      this.radiosShowHide = [$('#show-hide-radios-1'), $('#show-hide-radios-2')]
+
+      // Add show/hide content support
+      this.showHideContent = new GOVUK.ShowHideContent()
+      this.showHideContent.init()
+    })
+
+    it('should make the show/hide content visible if its radio is checked', function () {
+      this.$radio1.click()
+
+      // Defaults changed, initialise again
+      this.showHideContent = new GOVUK.ShowHideContent().init()
+      expect(this.$radio1.attr('aria-expanded')).toBe('true')
+      this.radiosShowHide.forEach(function ($showHide) {
+        expect($showHide.attr('aria-hidden')).toBe('false')
+        expect($showHide.hasClass('js-hidden')).toEqual(false)
+      })
+    })
+
+    it('should do nothing if a radio without show/hide content is checked', function () {
+      this.$radio2.click()
+
+      // Defaults changed, initialise again
+      this.showHideContent = new GOVUK.ShowHideContent().init()
+      expect(this.$radio1.attr('aria-expanded')).toBe('false')
+      this.radiosShowHide.forEach(function ($showHide) {
+        expect($showHide.attr('aria-hidden')).toBe('true')
+        expect($showHide.hasClass('js-hidden')).toEqual(true)
+      })
     })
   })
 })


### PR DESCRIPTION
### Allow showing/hiding of more than one target

The WC3 spec says that aria-controls should accept an ID
reference list, but our show/hide logic had been written in a way
that assumed only one id.

Extending the behaviour so that we can pass in a space-separated
string of ids to the "data-target" attribute and show/hide
multiple elements at once.

Source: https://www.w3.org/TR/wai-aria/states_and_properties#aria-controls

I can add something about this to the README if we're happy with it.

***

![multi](https://cloud.githubusercontent.com/assets/2454380/23138088/5fbfe56e-f79d-11e6-8671-8ceb8a0e28a2.gif)
