### PR TITLE
Enlarge mobile clickable areas on breadcrumbs and beta banners

### DIFF
--- a/stylesheets/_touch-friendly-links.scss
+++ b/stylesheets/_touch-friendly-links.scss
@@ -1,0 +1,10 @@
+// This mixin will expand the clickable area for a link to make it easier to click on a touch-enabled
+// device.
+
+@mixin touch-friendly-links($padding: 3px) {
+  a {
+    padding: $padding;
+    margin: -1 * $padding;
+    outline-color: transparent;
+  }
+}

--- a/stylesheets/design-patterns/_alpha-beta.scss
+++ b/stylesheets/design-patterns/_alpha-beta.scss
@@ -2,6 +2,7 @@
 @import "../typography";
 @import "../shims";
 @import "../grid_layout";
+@import "../touch-friendly-links";
 
 // Phase banner usage:
 //
@@ -38,6 +39,8 @@
     display: table-cell;
     vertical-align: baseline;
   }
+
+  @include touch-friendly-links();
 }
 
 // Phase tag usage:

--- a/stylesheets/design-patterns/_breadcrumbs.scss
+++ b/stylesheets/design-patterns/_breadcrumbs.scss
@@ -2,6 +2,7 @@
 @import "../typography";
 @import "../shims";
 @import "../url-helpers";
+@import "../touch-friendly-links";
 
 // Breadcrumbs usage:
 //
@@ -45,6 +46,8 @@
     }
 
   }
+
+  @include touch-friendly-links();
 
   a {
     color: $text-colour;


### PR DESCRIPTION
On mobile and tablet, the breadcrumb links and links inside the beta banner can be hard to click, because they are quite small.

This change increases their clickable area (whilst leaving their display the same).

# Phase banner

## Before

![phase-banner-before](https://cloud.githubusercontent.com/assets/12036746/23209985/7ae711e4-f8f3-11e6-8a38-6aa9a8ba667b.png)

## After

![phase-banner-after](https://cloud.githubusercontent.com/assets/12036746/23210011/8ef312fa-f8f3-11e6-9c66-c58ec0f4a72e.png)

# Breadcrumbs

## Before

![breadcrumbs-before](https://cloud.githubusercontent.com/assets/12036746/23210018/95ddba16-f8f3-11e6-84c9-5a7be1c2cbec.png)

## After

![breadcrumbs-after](https://cloud.githubusercontent.com/assets/12036746/23210019/98ad4d9c-f8f3-11e6-8bed-f2605af67b23.png)

This Pull Request replaces the same proposed change on [`static`](https://github.com/alphagov/static/pull/906).

Trello: https://trello.com/c/kSRKSoI2/326-review-styles-on-tablet-and-mobile-viewports-on-the-new-navigation-pages