### PR TITLE
Perform Travis deployment setup only when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,17 @@ language: node_js
 node_js:
   - "6.9.5"
 before_install:
+  # Node project, so Ruby dependencies must be installed manually (see `govuk-lint`)
+  - bundle install
+script:
+  - npm test
+before_deploy:
+  # Encrypted SSH config used to `push.sh` to Github (See `.travis/README.md`)
   - openssl aes-256-cbc -K $encrypted_909ac1036a94_key -iv $encrypted_909ac1036a94_iv -in .travis/govuk_frontend_toolkit_push.enc -out ~/.ssh/id_rsa -d
   - chmod 600 ~/.ssh/id_rsa
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis@travis-ci.org"
   - git remote add origin_ssh git@github.com:alphagov/govuk_frontend_toolkit.git
-  - bundle install
-script:
-  - npm test
 deploy:
   - provider: script
     script: './push.sh'


### PR DESCRIPTION
> ⚠️  Opening this as a fork, to simulate the situation in #383. I tested with the original implementation and the [build failed in the same way](https://travis-ci.org/alphagov/govuk_frontend_toolkit/builds/204953304)

Steps in `before_install` are run for all builds, not just deploys.

For branches/PRs from forks of this repo the install step fails as the user will not have access to the ENV vars used to decrypt files, like `encrypted_909ac1036a94_key`. This was caught in #383, where a forked PR build consistently fails on the `openssl` step.

Steps specified in `before_deploy` are only run if a deployment is triggered [1], which will only happen on `master`, which can't be triggered by a forked user.

Also adds a couple of inline comments to help explain the steps, which are a little obtuse at first glance.

[1] [Travis `before_deploy` documentation](https://docs.travis-ci.com/user/deployment/npm/#Running-commands-before-and-after-deploy)