### PR TITLE
Deprecate selection-buttons.js

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -342,6 +342,8 @@ and stop the elements before they get to the bottom.
 
 ## Selection buttons
 
+>If you are using GOV.UK Elements version 3.0.0 or above you *do not need* to include and initialise `GOVUK.SelectionButtons` to apply the correct radio button and checkbox styling. This module is deprecated and will be removed in the future.
+
 `GOVUK.SelectionButtons` adds classes to a parent `<label>` of a radio button or checkbox, allowing you to style it based on the input’s state. Given this example HTML structure:
 
 ```html

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -1,3 +1,6 @@
+// DEPRECATED
+// This isn’t needed if you’re using GOV.UK Elements 3.0.0 or above
+
 ;(function (global) {
   'use strict'
 

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -4,6 +4,10 @@
 ;(function (global) {
   'use strict'
 
+  if (window.console && window.console.warn) {
+    window.console.warn('Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.')
+  }
+
   var $ = global.jQuery
   var GOVUK = global.GOVUK || {}
 


### PR DESCRIPTION
GOV.UK Elements 3.0.0 will remove the need for GOVUK.SelectionButtons as it’s moving to a pure CSS solution. This adds documentation warnings that this is now deprecated and will be removed in future.

Probably worth waiting until 3.0.0 is released before merging this.