### PR TITLE
show-hide-content should work with new radio/checkbox markup

### DIFF
--- a/docs/javascript.md
+++ b/docs/javascript.md
@@ -464,13 +464,15 @@ GOVUK.shimLinksWithButtonRole.init({
 
 Script to support show/hide content, toggled by radio buttons and checkboxes. This allows for progressive disclosure of question and answer forms based on selected values:
 
-    <label class="block-label" data-target="show-me">
-      <input type="radio" name="enabled" value="yes" /> Yes
-    </label>
+    <div class="multiple-choice" data-target="show-me">
+      <input type="radio" name="enabled" value="yes" />
+      <label>Yes</label>
+    </div>
 
-    <label class="block-label">
-      <input type="radio" name="enabled" value="no" /> No
-    </label>
+    <div class="multiple-choice">
+      <input type="radio" name="enabled" value="no" />
+      <label>No</label>
+    </div>
 
     <div id="show-me" class="panel js-hidden">
       <p>Show/Hide content to be toggled</p>

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -10,8 +10,8 @@
     // Radio and Checkbox selectors
     var selectors = {
       namespace: 'ShowHideContent',
-      radio: '.block-label[data-target] input[type="radio"]',
-      checkbox: '.block-label[data-target] input[type="checkbox"]'
+      radio: '[data-target] > input[type="radio"]',
+      checkbox: '[data-target] > input[type="checkbox"]'
     }
 
     // Escape name attribute for use in DOM selector
@@ -39,7 +39,7 @@
 
       // ARIA attributes aren't set before init
       if (!id) {
-        id = $control.closest('label').data('target')
+        id = $control.closest('[data-target]').data('target')
       }
 
       // Find show/hide content by id

--- a/spec/unit/show-hide-content.spec.js
+++ b/spec/unit/show-hide-content.spec.js
@@ -21,31 +21,31 @@ describe('show-hide-content', function () {
 
         // Radio buttons (yes/no)
         '<form>' +
-        '<label class="block-label" data-target="show-hide-radios">' +
+        '<div class="multiple-choice" data-target="show-hide-radios">' +
         '<input type="radio" name="single" value="yes">' +
-        'Yes' +
-        '</label>' +
-        '<label class="block-label">' +
+        '<label>Yes</label>' +
+        '</div>' +
+        '<div class="multiple-choice">' +
         '<input type="radio" name="single" value="no">' +
-        'No' +
-        '</label>' +
+        '<label>No</label>' +
+        '</div>' +
         '<div id="show-hide-radios" class="panel js-hidden" />' +
         '</form>' +
 
         // Checkboxes (multiple values)
         '<form>' +
-        '<label class="block-label" data-target="show-hide-checkboxes">' +
+        '<div class="multiple-choice" data-target="show-hide-checkboxes">' +
         '<input type="checkbox" name="multiple[option1]">' +
-        'Option 1' +
-        '</label>' +
-        '<label class="block-label">' +
+        '<label>Option 1</label>' +
+        '</div>' +
+        '<div class="multiple-choice">' +
         '<input type="checkbox" name="multiple[option2]">' +
-        'Option 2' +
-        '</label>' +
-        '<label class="block-label">' +
+        '<label>Option 2</label>' +
+        '</div>' +
+        '<div class="multiple-choice">' +
         '<input type="checkbox" name="multiple[option3]">' +
-        'Option 3' +
-        '</label>' +
+        '<label>Option 3</label>' +
+        '</div>' +
         '<div id="show-hide-checkboxes" class="panel js-hidden" />' +
         '</form>'
       )
@@ -225,7 +225,7 @@ describe('show-hide-content', function () {
         }))
         expect(events && events.click).toContain(jasmine.objectContaining({
           namespace: 'ShowHideContent',
-          selector: '.block-label[data-target] input[type="checkbox"]'
+          selector: '[data-target] > input[type="checkbox"]'
         }))
       })
     })
@@ -243,7 +243,7 @@ describe('show-hide-content', function () {
         }))
         expect(events && events.click).not.toContain(jasmine.objectContaining({
           namespace: 'ShowHideContent',
-          selector: '.block-label[data-target] input[type="checkbox"]'
+          selector: '[data-target] > input[type="checkbox"]'
         }))
       })
     })
@@ -254,14 +254,14 @@ describe('show-hide-content', function () {
       // Sample markup
       this.$content = $(
         // Radio buttons (yes/no)
-        '<label class="block-label" data-target="show-hide-radios">' +
+        '<div class="multiple-choice" data-target="show-hide-radios">' +
         '<input type="radio" name="single" value="yes">' +
-        'Yes' +
-        '</label>' +
-        '<label class="block-label">' +
+        '<label>Yes</label>' +
+        '</div>' +
+        '<div class="multiple-choice">' +
         '<input type="radio" name="single" value="no">' +
-        'No' +
-        '</label>' +
+        '<label>No</label>' +
+        '</div>' +
         '<div id="show-hide-radios" class="panel js-hidden" />'
       )
 


### PR DESCRIPTION
- update the selectors in show-hide-content to work with both the new and original markup. Simply removing the `.block-label` left it feeling a bit unscoped, so I’ve added a direct child selector. This potentially could cause problems, but it works with our recommended markup old and new at least.
- update the spec to follow the new markup.
- update the documentation to recommend the new markup.

Things to consider:
- are the new selectors too restrictive?
- should we be testing both old and new markup?
- how could we decouple this in future further?