### PR TITLE
Fixes for Travis when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,15 @@ node_js:
 before_install:
   # Node project, so Ruby dependencies must be installed manually (see `govuk-lint`)
   - bundle install
-script:
-  - npm test
-before_deploy:
-  # Encrypted SSH config used to `push.sh` to Github (See `.travis/README.md`)
-  - openssl aes-256-cbc -K $encrypted_909ac1036a94_key -iv $encrypted_909ac1036a94_iv -in .travis/govuk_frontend_toolkit_push.enc -out ~/.ssh/id_rsa -d
-  - chmod 600 ~/.ssh/id_rsa
   - git config --global user.name "Travis CI"
   - git config --global user.email "travis@travis-ci.org"
   - git remote add origin_ssh git@github.com:alphagov/govuk_frontend_toolkit.git
+  # Encrypted SSH config used to `push.sh` to Github (See `.travis/README.md`)
+  - 'if [ "$TRAVIS_PULL_REQUEST_BRANCH" = "master" ]; then openssl aes-256-cbc -K $encrypted_909ac1036a94_key -iv $encrypted_909ac1036a94_iv -in .travis/govuk_frontend_toolkit_push.enc -out ~/.ssh/id_rsa -d && chmod 600 ~/.ssh/id_rsa; fi'
+script:
+  - npm test
+before_deploy:
+  - test $TRAVIS_TEST_RESULT = 0
 deploy:
   - provider: script
     script: './push.sh'


### PR DESCRIPTION
This PR moves the open_ssl command back to before_install, otherwise it runs
more than once (as there is more than one deploy provider).

Related Travis issue here:
https://github.com/travis-ci/travis-ci/issues/2570

This behaviour was reverted in GOV.UK elements here:
https://github.com/alphagov/govuk_elements/pull/415

Before deploying, also check that the build has passed successfully.