### PR TITLE
Fix environment variable - REPO_PATH

### DIFF
--- a/create-release.sh
+++ b/create-release.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 set -e
 
-REPO_PATH='govuk_frontend_toolkit'
+REPO_PATH="alphagov/govuk_frontend_toolkit"
 
 echo "Add config for alphagov/$REPO_PATH"
 
 git config --global user.name "Travis CI"
 git config --global user.email "travis@travis-ci.org"
-git remote add origin_ssh git@github.com:REPO_PATH.git
+git remote add origin_ssh git@github.com:$REPO_PATH.git
 
 # This openssl command was generated automatically by `travis encrypt-file`, see `.travis/README.md` for more details
 openssl aes-256-cbc -K $encrypted_909ac1036a94_key -iv $encrypted_909ac1036a94_iv -in .travis/govuk_frontend_toolkit_push.enc -out ~/.ssh/id_rsa -d


### PR DESCRIPTION
The Travis deployment failed - as REPO_PATH was missing both the organisation alphagov and also missing the $ to output the environment variable.

