### PR TITLE
Disable google analytics ad tracking

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -15,6 +15,11 @@
       sendToGa('set', 'anonymizeIp', true)
     }
 
+    function disableAdTracking () {
+      // https://support.google.com/analytics/answer/2444872?hl=en
+      sendToGa('set', 'displayFeaturesTask', null)
+    }
+
     // Support legacy cookieDomain param
     if (typeof fieldsObject === 'string') {
       fieldsObject = { cookieDomain: fieldsObject }
@@ -22,6 +27,7 @@
 
     configureProfile()
     anonymizeIp()
+    disableAdTracking()
   }
 
   GoogleAnalyticsUniversalTracker.load = function () {

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -147,6 +147,7 @@
     sendToGa(name + '.linker:autoLink', [domain])
 
     sendToGa(name + '.set', 'anonymizeIp', true)
+    sendToGa(name + '.set', 'displayFeaturesTask', null)
     sendToGa(name + '.send', 'pageview')
   }
 

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -29,6 +29,8 @@ describe('GOVUK.Analytics', function () {
 
     it('configures a universal tracker', function () {
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk', siteSpeedSampleRate: 100}])
+      expect(universalSetupArguments[1]).toEqual(['set', 'anonymizeIp', true])
+      expect(universalSetupArguments[2]).toEqual(['set', 'displayFeaturesTask', null])
     })
   })
 
@@ -69,6 +71,7 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['linker:autoLink', ['www.example.com']])
       expect(allArgs).toContain(['test.linker:autoLink', ['www.example.com']])
       expect(allArgs).toContain(['test.set', 'anonymizeIp', true])
+      expect(allArgs).toContain(['test.set', 'displayFeaturesTask', null])
       expect(allArgs).toContain(['test.send', 'pageview'])
     })
   })


### PR DESCRIPTION
I'm finding this difficult to test but this does seem to stop requests
to ga-audience and doubleclick.

Discovered when checking some waterfall logs, seen in external tools such as
SpeedCurve, WebPageTest.

To test I tried this locally, it seems these endpoints are only called on initial visit
which makes it hard to reproduce.

Fixes: https://github.com/alphagov/static/issues/991

Will need sign off from the Performance Analysis community

It'd be good to get someone else to try and reproduce this locally too.