### PR TITLE
Only make GOV.UK analytics call when GA is ready

### DIFF
--- a/javascripts/govuk/analytics/govuk-tracker.js
+++ b/javascripts/govuk/analytics/govuk-tracker.js
@@ -7,11 +7,6 @@
   var GOVUKTracker = function (gifUrl) {
     this.gifUrl = gifUrl
     this.dimensions = []
-    if (global.ga) {
-      global.ga(function (tracker) {
-        this.gaClientId = tracker.get('clientId')
-      }.bind(this))
-    }
   }
 
   GOVUKTracker.load = function () {}
@@ -118,7 +113,14 @@
 
   GOVUKTracker.prototype.sendToTracker = function (type, payload) {
     $(global.document).ready(function () {
-      this.sendData(this.payloadParams(type, payload))
+      if (global.ga) {
+        global.ga(function (tracker) {
+          this.gaClientId = tracker.get('clientId')
+          this.sendData(this.payloadParams(type, payload))
+        }.bind(this))
+      } else {
+        this.sendData(this.payloadParams(type, payload))
+      }
     }.bind(this))
   }
 

--- a/spec/unit/analytics/govuk-tracker.spec.js
+++ b/spec/unit/analytics/govuk-tracker.spec.js
@@ -8,6 +8,14 @@ describe('GOVUK.GOVUKTracker', function () {
 
   var tracker
 
+  function setupFakeGa (clientId) {
+    window.ga = function (cb) {
+      cb({
+        get: function () { return clientId }
+      })
+    }
+  }
+
   beforeEach(function () {
     tracker = new GOVUK.GOVUKTracker('http://www.example.com/a.gif')
   })
@@ -74,10 +82,21 @@ describe('GOVUK.GOVUKTracker', function () {
 
   describe('sendToTracker', function () {
     it('sends when the DOM is complete', function () {
+      setupFakeGa('123456.789012')
+
       spyOn(tracker, 'sendData')
       tracker.sendToTracker('foo')
 
       expect(tracker.sendData).toHaveBeenCalledWith(jasmine.any(Object))
+    })
+
+    it('sets the ga Client ID', function () {
+      setupFakeGa('123456.789012')
+
+      spyOn(tracker, 'sendData')
+      tracker.sendToTracker('foo')
+
+      expect(tracker.gaClientId).toEqual('123456.789012')
     })
   })
 


### PR DESCRIPTION
We want to send the `gaClientId` with our GOV.UK analytics payload, but
due to asynchronous loading we may not have actually fetched it from
the GA library by the time `sendToTracker` is called.

If GA is enabled on this page, we now wrap the call to `sendData` in
the “ga ready” callback function and make sure we set the clientId
first.