### PR TITLE
Use the more sensibly named govukTrackerUrl config name

### DIFF
--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -13,10 +13,10 @@
       delete config.universalId
       this.trackers.push(new GOVUK.GoogleAnalyticsUniversalTracker(universalId, config))
     }
-    if (typeof config.govukTrackerGifUrl !== 'undefined') {
-      var govukTrackerGifUrl = config.govukTrackerGifUrl
-      delete config.govukTrackerGifUrl
-      this.trackers.push(new GOVUK.GOVUKTracker(govukTrackerGifUrl))
+    if (typeof config.govukTrackerUrl !== 'undefined') {
+      var govukTrackerUrl = config.govukTrackerUrl
+      delete config.govukTrackerUrl
+      this.trackers.push(new GOVUK.GOVUKTracker(govukTrackerUrl))
     }
   }
 


### PR DESCRIPTION
Use `govukTrackerUrl` for configuration instead, as gifs aren’t
involved anywhere.