### PR TITLE
Fix js error causing missing accordions in IE7

### DIFF
--- a/javascripts/govuk/modules.js
+++ b/javascripts/govuk/modules.js
@@ -46,7 +46,7 @@
       // http://stackoverflow.com/questions/6660977/convert-hyphens-to-camel-case-camelcase
       function camelCase (string) {
         return string.replace(/-([a-z])/g, function (g) {
-          return g[1].toUpperCase()
+          return g.charAt(1).toUpperCase()
         })
       }
 


### PR DESCRIPTION
Accessing individual characters in strings as if they are arrays is an ECMAScript 5 feature which was only introduced in IE8. So IE 7 and below (and IE11 _when in compatibility mode_) are erroring because of this.

Notably this is leaving accordions in a state where the original page content has been removed (because they use the js-hidden class), but the accordion fails to initialise, leaving the user with no way to navigate further.

We can fix this by using `charAt`[1] as recommended by MDN [2]

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt
[2]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access