### PR TITLE
Increase button focus specificity to avoid being overridden

### DIFF
--- a/stylesheets/design-patterns/_buttons.scss
+++ b/stylesheets/design-patterns/_buttons.scss
@@ -87,6 +87,7 @@
     color: $white;
 
     &:link,
+    &:link:focus,
     &:hover,
     &:focus,
     &:visited {
@@ -96,6 +97,7 @@
     color: $text-colour;
 
     &:link,
+    &:link:focus,
     &:hover,
     &:focus,
     &:visited {


### PR DESCRIPTION
We've updated govuk_template link focus styles which now overrides our buttons

![screen shot 2017-05-10 at 14 04 53](https://cloud.githubusercontent.com/assets/2445413/25899949/ae4bb24c-3589-11e7-8960-da0ac0edb483.png)

As seen in https://www.gov.uk/book-driving-test

Introduced here: https://github.com/alphagov/govuk_template/commit/79466a489c38b0b82f4cb95daa2baba41b375a81

This kind of bug will hopefully be much more obvious when we merge these two repos as part of the new GOV.UK Frontend project :)