### PR TITLE
Add docs for releasing a new version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,13 @@ guidelines:
 
 ## Versioning
 
-We use [semantic versioning](http://semver.org/), and bump the version
-on master only. Please don't submit your own proposed version numbers.
+We use [Semantic Versioning](http://semver.org/).
+
+## Releasing a new version 
+
+1. Create a branch that proposes a new [version number](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/VERSION.txt) and update the [`CHANGELOG`](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md).
+2. Open a Pull Request - here is a [good example](https://github.com/alphagov/govuk_frontend_toolkit/pull/396).
+3. Once merged into master a new version will be built and [downstream jobs triggered by Travis CI](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/.travis.yml) for [govuk_frontend_toolkit_gem](https://github.com/alphagov/govuk_frontend_toolkit_gem) and [govuk_frontend_toolkit_npm](https://github.com/alphagov/govuk_frontend_toolkit_npm).
 
 ## Commit hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We use [Semantic Versioning](http://semver.org/).
 
 ## Releasing a new version 
 
-1. Create a branch that proposes a new [version number](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/VERSION.txt) and update the [`CHANGELOG`](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md).
+1. Create a branch that proposes a new [version number](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/VERSION.txt) and update the [`CHANGELOG`](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/CHANGELOG.md). To see the commits to be summarised in the changelog since the last release, [compare the latest-release branch with master](https://github.com/alphagov/govuk_frontend_toolkit/compare/latest-release...master).
 2. Open a Pull Request - here is a [good example](https://github.com/alphagov/govuk_frontend_toolkit/pull/396).
 3. Once merged into master a new version will be built and [downstream jobs triggered by Travis CI](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/.travis.yml) for [govuk_frontend_toolkit_gem](https://github.com/alphagov/govuk_frontend_toolkit_gem) and [govuk_frontend_toolkit_npm](https://github.com/alphagov/govuk_frontend_toolkit_npm).
 


### PR DESCRIPTION
Add docs to CONTRIBUTING.md, in the same style as those for govuk_template, with examples updated for this repo.

https://github.com/alphagov/govuk_template/blob/master/CONTRIBUTING.md#releasing-a-new-version