### PR TITLE
Allow options object in trackShare function

### DIFF
--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -50,8 +50,8 @@
     this.sendToTrackers('trackEvent', arguments)
   }
 
-  Analytics.prototype.trackShare = function (network) {
-    this.sendToTrackers('trackSocial', [network, 'share', global.location.pathname])
+  Analytics.prototype.trackShare = function (network, options) {
+    this.sendToTrackers('trackSocial', [network, 'share', global.location.pathname, options])
   }
 
   /*

--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -112,13 +112,17 @@
     target – Specifies the target of a social interaction.
              This value is typically a URL but can be any text.
   */
-  GoogleAnalyticsUniversalTracker.prototype.trackSocial = function (network, action, target) {
-    sendToGa('send', {
+  GoogleAnalyticsUniversalTracker.prototype.trackSocial = function (network, action, target, options) {
+    var trackingOptions = {
       'hitType': 'social',
       'socialNetwork': network,
       'socialAction': action,
       'socialTarget': target
-    })
+    }
+
+    $.extend(trackingOptions, options)
+
+    sendToGa('send', trackingOptions)
   }
 
   /*

--- a/javascripts/govuk/analytics/govuk-tracker.js
+++ b/javascripts/govuk/analytics/govuk-tracker.js
@@ -61,12 +61,16 @@
     this.sendToTracker('event', evt)
   }
 
-  GOVUKTracker.prototype.trackSocial = function (network, action, target) {
-    this.sendToTracker('social', {
+  GOVUKTracker.prototype.trackSocial = function (network, action, target, options) {
+    var trackingOptions = {
       'socialNetwork': network,
       'socialAction': action,
       'socialTarget': target
-    })
+    }
+
+    $.extend(trackingOptions, options)
+
+    this.sendToTracker('social', trackingOptions)
   }
 
   GOVUKTracker.prototype.addLinkedTrackerDomain = function () { /* noop */ }


### PR DESCRIPTION
As part of a refactoring in `static-analytics.js` in `static`, we
removed session-level dimension setting, and all dimensions must now
be explicitly declared.

A result of this is that we must pass these into the `trackShare`
function. This change adds this capability.