### PR TITLE
Fixes media player volume button overlap

### DIFF
--- a/stylesheets/design-patterns/_media-player.scss
+++ b/stylesheets/design-patterns/_media-player.scss
@@ -110,7 +110,7 @@
       .mute {
         position: absolute;
         bottom: 0;
-        left: 120px;
+        right: 0;
         height: 40px;
         width: 50px;
         padding-top: 1px;
@@ -141,7 +141,6 @@
         bottom: 0;
         height: 40px;
         width: 60px;
-        padding-top: 2px;
         font-size: 24px;
         line-height: 40px;
         text-align: center;
@@ -150,6 +149,21 @@
         &:hover,
         &:focus {
           color: $light-blue;
+          background-color: transparent;
+          outline: none;
+
+          &:before {
+            background-color: $focus-colour;
+          }
+        }
+
+        &:before {
+          content: "";
+          display: inline-block;
+          position: absolute;
+          width: 50%;
+          height: 100%;
+          z-index: -1;
         }
       }
 
@@ -157,18 +171,26 @@
         text-align: left;
         padding-left: 10px;
         left: 0;
+
+        &:before {
+          left: 0;
+        }
       }
 
       .vol-up {
         text-align: right;
         padding-right: 10px;
-        left: 60px;
+        left: 65px;
+
+        &:before {
+          right: 0;
+        }
       }
 
       .vol-display {
         position: absolute;
         bottom: 0;
-        left: 20px;
+        left: 25px;
         height: 40px;
         width: 0;
         padding-left: 35px;
@@ -185,7 +207,7 @@
     .current-time {
       position: absolute;
       bottom: 0;
-      left: 50px;
+      left: 45px;
       height: 40px;
       font-size: 14px;
       line-height: 40px;


### PR DESCRIPTION
Fixes [#853](https://github.com/alphagov/static/issues/853). Volume up and down buttons in the media player were overlapping the current volume percentage on focus. This fix keeps the large button touch area, but adjust the focus state to be smaller.

**Before: volume button focus state overlaps the current volume percentage:**
<img width="202" alt="screen shot 2017-07-18 at 14 36 38" src="https://user-images.githubusercontent.com/29889908/28319722-9eb559b4-6bc6-11e7-85f6-9b99937142a8.png">

**After: volume button touch area remains the same as previously, but focus state is smaller so as not to obscure current volume percentage:**
This shows the new focus state:
<img width="133" alt="screen shot 2017-07-18 at 14 14 51" src="https://user-images.githubusercontent.com/29889908/28319782-cc198a7e-6bc6-11e7-98d1-d81ebbc31722.png">

But we can see that the touch area remains the same:
<img width="528" alt="screen shot 2017-07-18 at 14 14 35" src="https://user-images.githubusercontent.com/29889908/28319791-cea89dc0-6bc6-11e7-8a12-48c4cade43f8.png">

This means the volume controls continue to work on small devices where all icons are more closely located together:
<img width="289" alt="screen shot 2017-07-18 at 14 15 34" src="https://user-images.githubusercontent.com/29889908/28319867-fde24906-6bc6-11e7-9925-81fa8d562815.png">


