### PR TITLE
Avoid Personally Identifiable Information (PII) being sent to Google Analytics (GA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Strip PII from all arguments passed to GA.  Emails are stripped by default, postcodes can also be stripped if configured to do so.
+
 # 7.2.0
 
 - Add custom dimension on TrackEvent to duplicate the url information that we normally send on a the `event action`. This will be used to join up with a scheduled custom upload called "External Link Status". We can only join uploads on custom dimensions, not on `event actions`, where we normally add the url info. ([PR #436](alphagov/govuk_frontend_toolkit#436) and [PR #439](alphagov/govuk_frontend_toolkit#439))

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -7,6 +7,7 @@ The toolkit provides an abstraction around analytics to make tracking pageviews,
 * a generic Analytics wrapper that allows multiple trackers to be configured
 * sensible defaults such as anonymising IPs
 * data coercion into the format required by Google Analytics (eg a custom dimension’s value must be a string)
+* stripping of PII from data sent to the tracker (strips email by default, can be configured to also strip UK postcodes)
 
 ## Create an analytics tracker
 
@@ -216,3 +217,35 @@ plugin uses Google Analytics’ `transport: beacon` method so that events are tr
 Category | Action | Label
 ---------|--------|-------
 Mailto Link Clicked | mailto:name@email.com | Link text
+
+### Stripping Personally Identifiable Information (PII)
+
+The tracker will strip any PII it detects from all arguments sent to the
+tracker.  If a PII is detected in the arguments it is replaced with a
+placeholder value of `[<type of PII removed>]`; for example: `[email]` if an
+email address was removed, or `[postcode]` if a postcode was removed.
+
+We have to parse all arguments which means that if you don't pass a path to
+`trackPageView` to track the current page we have to extract the current page
+and parse it, turning all `trackPageView` calls into ones with a path argument.
+We use `window.location.href.split('#')[0]` as the default path when one is
+not provided.  The original behaviour would have been to ignore the anchor
+part of the URL anyway so this doesn't change the behaviour other than to make
+the path explicit.
+
+By default we strip email addresses, but it can also be configured to strip
+postcodes too.  Postcodes are off by default because they're more likely to
+cause false positives.  If you know you are likely to include postcodes in
+the data you send to the tracker you can configure to strip postcodes at
+initialize time as follows:
+
+```js
+  GOVUK.analytics = new GOVUK.Analytics({
+    universalId: 'UA-XXXXXXXX-X',
+    cookieDomain: cookieDomain,
+    stripPostcodePII: true
+  });
+````
+
+Any value other than the JS literal `true` for `stripPostcodePII` will leave
+the analytics module configured not to strip postcodes.

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -20,6 +20,40 @@
     }
   }
 
+  Analytics.prototype.stripPII = function (value) {
+    if (typeof value === 'string') {
+      return this.stripPIIFromString(value)
+    } else if (Object.prototype.toString.call(value) === '[object Array]') {
+      return this.stripPIIFromArray(value)
+    } else if (typeof value === 'object') {
+      return this.stripPIIFromObject(value)
+    } else {
+      return value
+    }
+  }
+
+  Analytics.prototype.stripPIIFromString = function (string) {
+    return string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[email]')
+  }
+
+  Analytics.prototype.stripPIIFromObject = function (object) {
+    for (var property in object) {
+      var value = object[property]
+
+      object[property] = this.stripPII(value)
+    }
+    return object
+  }
+
+  Analytics.prototype.stripPIIFromArray = function (array) {
+    for (var i = 0, l = array.length; i < l; i++) {
+      var elem = array[i]
+
+      array[i] = this.stripPII(elem)
+    }
+    return array
+  }
+
   Analytics.prototype.sendToTrackers = function (method, args) {
     for (var i = 0, l = this.trackers.length; i < l; i++) {
       var tracker = this.trackers[i]
@@ -37,7 +71,7 @@
   }
 
   Analytics.prototype.trackPageview = function (path, title, options) {
-    this.sendToTrackers('trackPageview', arguments)
+    this.sendToTrackers('trackPageview', this.stripPII(arguments))
   }
 
   /*
@@ -47,11 +81,11 @@
     options.nonInteraction – Prevent event from impacting bounce rate
   */
   Analytics.prototype.trackEvent = function (category, action, options) {
-    this.sendToTrackers('trackEvent', arguments)
+    this.sendToTrackers('trackEvent', this.stripPII(arguments))
   }
 
   Analytics.prototype.trackShare = function (network, options) {
-    this.sendToTrackers('trackSocial', [network, 'share', global.location.pathname, options])
+    this.sendToTrackers('trackSocial', this.stripPII([network, 'share', global.location.pathname, options]))
   }
 
   /*
@@ -59,7 +93,7 @@
     Universal Analytics profile
    */
   Analytics.prototype.setDimension = function (index, value) {
-    this.sendToTrackers('setDimension', arguments)
+    this.sendToTrackers('setDimension', this.stripPII(arguments))
   }
 
   /*

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -2,6 +2,8 @@
   'use strict'
 
   var GOVUK = global.GOVUK || {}
+  var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
 
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
@@ -33,7 +35,7 @@
   }
 
   Analytics.prototype.stripPIIFromString = function (string) {
-    return string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[email]')
+    return string.replace(EMAIL_PATTERN, '[email]').replace(POSTCODE_PATTERN, '[postcode]')
   }
 
   Analytics.prototype.stripPIIFromObject = function (object) {

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -32,6 +32,71 @@ describe('GOVUK.Analytics', function () {
       expect(universalSetupArguments[1]).toEqual(['set', 'anonymizeIp', true])
       expect(universalSetupArguments[2]).toEqual(['set', 'displayFeaturesTask', null])
     })
+
+    it('is configured not to strip postcode data from GA calls', function () {
+      expect(analytics.stripPostcodePII).toEqual(false)
+    })
+
+    it('can be told to strip postcode data from GA calls', function () {
+      analytics = new GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: '.www.gov.uk',
+        siteSpeedSampleRate: 100,
+        stripPostcodePII: true
+      })
+
+      expect(analytics.stripPostcodePII).toEqual(true)
+    })
+  })
+
+  describe('tracking pageviews', function () {
+    beforeEach(function () {
+      spyOn(analytics, 'defaultPathForTrackPageview').and.returnValue('https://govuk-frontend-toolkit.example.com/a/page?with=a&query=string')
+    })
+
+    it('injects a default path if no args are supplied', function () {
+      analytics.trackPageview()
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].page).toEqual('https://govuk-frontend-toolkit.example.com/a/page?with=a&query=string')
+    })
+
+    it('injects a default path if args are supplied, but the path arg is blank', function () {
+      analytics.trackPageview(null)
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].page).toEqual('https://govuk-frontend-toolkit.example.com/a/page?with=a&query=string')
+
+      analytics.trackPageview(undefined)
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].page).toEqual('https://govuk-frontend-toolkit.example.com/a/page?with=a&query=string')
+    })
+
+    it('uses the supplied path', function () {
+      analytics.trackPageview('/foo')
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].page).toEqual('/foo')
+    })
+
+    it('does not inject a default title if no args are supplied', function () {
+      analytics.trackPageview()
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].title).toEqual(undefined)
+    })
+
+    it('does not inject a default title if args are supplied, but the title arg is blank', function () {
+      analytics.trackPageview('/foo', null)
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].title).toEqual(undefined)
+
+      analytics.trackPageview('/foo', undefined)
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].title).toEqual(undefined)
+    })
+
+    it('uses the supplied title', function () {
+      analytics.trackPageview('/foo', 'A page')
+      console.log(window.ga.calls.mostRecent().args)
+      expect(window.ga.calls.mostRecent().args[2].title).toEqual('A page')
+    })
   })
 
   describe('when tracking pageviews, events and custom dimensions', function () {
@@ -57,7 +122,25 @@ describe('GOVUK.Analytics', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', '[email]']) // set dimension ignores extra options
     })
 
-    it('strips postcodes embedded in arguments', function () {
+    it('leaves postcodes embedded in arguments by default', function () {
+      analytics.trackPageview('/path/to/an/embedded/SW1+1AA/postcode/?with=an&postcode=SP4%207DE', 'TD15 2SE', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', { page: '/path/to/an/embedded/SW1+1AA/postcode/?with=an&postcode=SP4%207DE', title: 'TD15 2SE', label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] }])
+
+      analytics.trackEvent('SW1+1AA-category', 'SP4%207DE-action', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', { hitType: 'event', eventCategory: 'SW1+1AA-category', eventAction: 'SP4%207DE-action', eventLabel: 'RG209NJ' }]) // trackEvent ignores options other than label or integer values for value
+
+      analytics.setDimension(1, 'SW1+1AA-value', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', 'SW1+1AA-value']) // set dimension ignores extra options
+    })
+
+    it('strips postcodes embedded in arguments if configured to do so', function () {
+      analytics = new GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: '.www.gov.uk',
+        siteSpeedSampleRate: 100,
+        stripPostcodePII: true
+      })
+
       analytics.trackPageview('/path/to/an/embedded/SW1+1AA/postcode/?with=an&postcode=SP4%207DE', 'TD15 2SE', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
       expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', { page: '/path/to/an/embedded/[postcode]/postcode/?with=an&postcode=[postcode]', title: '[postcode]', label: '[postcode]', value: ['data', 'data', 'someone has added their personal[postcode] postcode'] }])
 
@@ -99,7 +182,32 @@ describe('GOVUK.Analytics', function () {
       }])
     })
 
-    it('strips postcodes embedded in arguments', function () {
+    it('leaves postcodes embedded in arguments by default', function () {
+      analytics.trackShare('email', {
+        to: 'IV63 6TU',
+        label: 'SP4%207DE',
+        value: ['data', 'data', 'someone has added their personalTD15 2SE postcode']
+      })
+
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', {
+        hitType: 'social',
+        socialNetwork: 'email',
+        socialAction: 'share',
+        socialTarget: jasmine.any(String),
+        to: 'IV63 6TU',
+        label: 'SP4%207DE',
+        value: ['data', 'data', 'someone has added their personalTD15 2SE postcode']
+      }])
+    })
+
+    it('strips postcodes embedded in arguments if configured to do so', function () {
+      analytics = new GOVUK.Analytics({
+        universalId: 'universal-id',
+        cookieDomain: '.www.gov.uk',
+        siteSpeedSampleRate: 100,
+        stripPostcodePII: true
+      })
+
       analytics.trackShare('email', {
         to: 'IV63 6TU',
         label: 'SP4%207DE',

--- a/spec/unit/analytics/analytics.spec.js
+++ b/spec/unit/analytics/analytics.spec.js
@@ -56,6 +56,17 @@ describe('GOVUK.Analytics', function () {
       analytics.setDimension(1, 'an_email@example.com_address-value', { label: 'another.email@example.com', value: ['data', 'data', 'someone has added their personal.email@example.com address'] })
       expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', '[email]']) // set dimension ignores extra options
     })
+
+    it('strips postcodes embedded in arguments', function () {
+      analytics.trackPageview('/path/to/an/embedded/SW1+1AA/postcode/?with=an&postcode=SP4%207DE', 'TD15 2SE', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', { page: '/path/to/an/embedded/[postcode]/postcode/?with=an&postcode=[postcode]', title: '[postcode]', label: '[postcode]', value: ['data', 'data', 'someone has added their personal[postcode] postcode'] }])
+
+      analytics.trackEvent('SW1+1AA-category', 'SP4%207DE-action', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', { hitType: 'event', eventCategory: '[postcode]-category', eventAction: '[postcode]-action', eventLabel: '[postcode]' }]) // trackEvent ignores options other than label or integer values for value
+
+      analytics.setDimension(1, 'SW1+1AA-value', { label: 'RG209NJ', value: ['data', 'data', 'someone has added their personalIV63 6TU postcode'] })
+      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', '[postcode]-value']) // set dimension ignores extra options
+    })
   })
 
   describe('when tracking social media shares', function () {
@@ -85,6 +96,24 @@ describe('GOVUK.Analytics', function () {
         to: '[email]',
         label: '[email]',
         value: ['data', 'data', 'someone has added their [email] address']
+      }])
+    })
+
+    it('strips postcodes embedded in arguments', function () {
+      analytics.trackShare('email', {
+        to: 'IV63 6TU',
+        label: 'SP4%207DE',
+        value: ['data', 'data', 'someone has added their personalTD15 2SE postcode']
+      })
+
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', {
+        hitType: 'social',
+        socialNetwork: 'email',
+        socialAction: 'share',
+        socialTarget: jasmine.any(String),
+        to: '[postcode]',
+        label: '[postcode]',
+        value: ['data', 'data', 'someone has added their personal[postcode] postcode']
       }])
     })
   })


### PR DESCRIPTION
For: https://trello.com/c/ilkmeS5E/239-investigate-preventing-pii-being-sent-to-ga

Our goal is to remove Personally Identifiable Information (PII) from any data we send to Google Analytics (GA).  We strip email addresses (or things that look like them) by default and we can configure it to also strip postcodes (or things that look like them) too.  We don't turn on postcodes by default because too many things (airplane call signs, form names, etc..) look like postcodes but aren't and would be stripped out as false positives.  However it's configurable so that for the places we know where postcodes are used, we can turn on stripping them out.