### PR TITLE
Add custom dimension to be joined on by GA upload

### DIFF
--- a/javascripts/govuk/analytics/external-link-tracker.js
+++ b/javascripts/govuk/analytics/external-link-tracker.js
@@ -21,6 +21,15 @@
         options.label = linkText
       }
 
+      // This custom dimension will be used to duplicate the url information
+      // that we normally send in an "event action". This will be used to join
+      // up with a scheduled custom upload called "External Link Status".
+      // We can only join uploads on custom dimensions, not on `event actions`
+      // where we normally add the url info.
+      var googleAnalyticsExternalLinkUploadDimension = 36
+      var urlDimensionToJoinUploadOn = href
+
+      GOVUK.analytics.setDimension(googleAnalyticsExternalLinkUploadDimension, urlDimensionToJoinUploadOn)
       GOVUK.analytics.trackEvent('External Link Clicked', href, options)
     }
 

--- a/spec/unit/analytics/external-link-tracker.spec.js
+++ b/spec/unit/analytics/external-link-tracker.spec.js
@@ -24,7 +24,10 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
 
     $('html').on('click', function (evt) { evt.preventDefault() })
     $('body').append($links)
-    GOVUK.analytics = {trackEvent: function () {}}
+    GOVUK.analytics = {
+      trackEvent: function () {},
+      setDimension: function () {}
+    }
 
     spyOn(GOVUK.analyticsPlugins.externalLinkTracker, 'getHostname').and.returnValue('fake-hostname.com')
     GOVUK.analyticsPlugins.externalLinkTracker()
@@ -73,5 +76,15 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'External Link Clicked', 'https://www.nationalarchives.gov.uk/one.pdf', {transport: 'beacon', label: 'National Archives PDF'})
+  })
+
+  it('duplicates the url info in a custom dimension to be used to join with a Google Analytics upload', function () {
+    spyOn(GOVUK.analytics, 'setDimension')
+    spyOn(GOVUK.analytics, 'trackEvent')
+    $('.external-links a').trigger('click')
+
+    expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(36, 'http://www.nationalarchives.gov.uk')
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'External Link Clicked', 'http://www.nationalarchives.gov.uk', {transport: 'beacon', label: 'National Archives'})
   })
 })


### PR DESCRIPTION
For: https://trello.com/c/SYgBUl4q/258-develop-an-upload-to-ga-of-link-checker-data

## WHAT

This change is meant to duplicate the url information in a custom dimension. The url is usually sent in the event action. However, we need this info to also be present in a custom dimension.

## WHY
The reason for this is that we are doing a join between the click hit data and the information we upload via a Google Analytics Custom Upload. The custom upload is called "External Link Status" and needs to join existing data strictly on a custom dimension.