### PR TITLE
Allow custom dimension for uploads to be optional

### DIFF
--- a/javascripts/govuk/analytics/external-link-tracker.js
+++ b/javascripts/govuk/analytics/external-link-tracker.js
@@ -5,7 +5,9 @@
   var GOVUK = global.GOVUK || {}
 
   GOVUK.analyticsPlugins = GOVUK.analyticsPlugins || {}
-  GOVUK.analyticsPlugins.externalLinkTracker = function () {
+  GOVUK.analyticsPlugins.externalLinkTracker = function (options) {
+    options = options || {}
+    var externalLinkUploadCustomDimension = options.externalLinkUploadCustomDimension
     var currentHost = GOVUK.analyticsPlugins.externalLinkTracker.getHostname()
     var externalLinkSelector = 'a[href^="http"]:not(a[href*="' + currentHost + '"])'
 
@@ -21,15 +23,17 @@
         options.label = linkText
       }
 
-      // This custom dimension will be used to duplicate the url information
-      // that we normally send in an "event action". This will be used to join
-      // up with a scheduled custom upload called "External Link Status".
-      // We can only join uploads on custom dimensions, not on `event actions`
-      // where we normally add the url info.
-      var googleAnalyticsExternalLinkUploadDimension = 36
-      var urlDimensionToJoinUploadOn = href
+      if (externalLinkUploadCustomDimension !== undefined) {
+        // This custom dimension will be used to duplicate the url information
+        // that we normally send in an "event action". This will be used to join
+        // up with a scheduled custom upload called "External Link Status".
+        // We can only join uploads on custom dimensions, not on `event actions`
+        // where we normally add the url info.
+        var externalLinkToJoinUploadOn = href
 
-      GOVUK.analytics.setDimension(googleAnalyticsExternalLinkUploadDimension, urlDimensionToJoinUploadOn)
+        GOVUK.analytics.setDimension(externalLinkUploadCustomDimension, externalLinkToJoinUploadOn)
+      }
+
       GOVUK.analytics.trackEvent('External Link Clicked', href, options)
     }
 

--- a/spec/unit/analytics/external-link-tracker.spec.js
+++ b/spec/unit/analytics/external-link-tracker.spec.js
@@ -30,7 +30,6 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
     }
 
     spyOn(GOVUK.analyticsPlugins.externalLinkTracker, 'getHostname').and.returnValue('fake-hostname.com')
-    GOVUK.analyticsPlugins.externalLinkTracker()
   })
 
   afterEach(function () {
@@ -41,6 +40,8 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
   })
 
   it('listens to click events on only external links', function () {
+    GOVUK.analyticsPlugins.externalLinkTracker({externalLinkUploadCustomDimension: 36})
+
     spyOn(GOVUK.analytics, 'trackEvent')
 
     $('.external-links a').each(function () {
@@ -57,6 +58,8 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
   })
 
   it('listens to click events on elements within external links', function () {
+    GOVUK.analyticsPlugins.externalLinkTracker({externalLinkUploadCustomDimension: 36})
+
     spyOn(GOVUK.analytics, 'trackEvent')
 
     $('.external-links a img').trigger('click')
@@ -65,6 +68,8 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
   })
 
   it('tracks an external link\'s href and link text', function () {
+    GOVUK.analyticsPlugins.externalLinkTracker({externalLinkUploadCustomDimension: 36})
+
     spyOn(GOVUK.analytics, 'trackEvent')
     $('.external-links a').trigger('click')
 
@@ -79,11 +84,25 @@ describe('GOVUK.analyticsPlugins.externalLinkTracker', function () {
   })
 
   it('duplicates the url info in a custom dimension to be used to join with a Google Analytics upload', function () {
+    GOVUK.analyticsPlugins.externalLinkTracker({externalLinkUploadCustomDimension: 36})
+
     spyOn(GOVUK.analytics, 'setDimension')
     spyOn(GOVUK.analytics, 'trackEvent')
     $('.external-links a').trigger('click')
 
     expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(36, 'http://www.nationalarchives.gov.uk')
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'External Link Clicked', 'http://www.nationalarchives.gov.uk', {transport: 'beacon', label: 'National Archives'})
+  })
+
+  it('does not duplicate the url info if a custom dimension is not provided', function () {
+    GOVUK.analyticsPlugins.externalLinkTracker()
+
+    spyOn(GOVUK.analytics, 'setDimension')
+    spyOn(GOVUK.analytics, 'trackEvent')
+    $('.external-links a').trigger('click')
+
+    expect(GOVUK.analytics.setDimension).not.toHaveBeenCalled()
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'External Link Clicked', 'http://www.nationalarchives.gov.uk', {transport: 'beacon', label: 'National Archives'})
   })


### PR DESCRIPTION
For: https://trello.com/c/SYgBUl4q/258-develop-an-upload-to-ga-of-link-checker-data

Previous work (seen here: https://github.com/alphagov/govuk_frontend_toolkit/pull/436) has been done to allow us to duplicate the url information we normally store in an `event action`. We duplicate this info into a custom dimension in order to be able to do a join later within Google Analytics with a custom upload setup to report the status of links.
We weren't able to do the join on the info in an event action, only on a custom dimension.

However, it's been pointed out that the `govuk_frontend_toolkit` gem is being used for other projects besides `gov.uk` so would inadvertently use their custom dimension to duplicate this url info, without their approval.
So we've made this behavior optional.
If a custom dimension is not provided, then the behavior is turned off.

Depends on https://github.com/alphagov/static/pull/1192