### PR TITLE
Provide `PIISafe` wrapper object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+
+- Allow wrapping arguments to analytics as PII safe to tell the analytics code not to attempt to strip PII from the values: ([PR #448](https://github.com/alphagov/govuk_frontend_toolkit/pull/448))
 # 7.3.0
 
 - Strip PII from all arguments passed to GA.  Emails are stripped by default, postcodes can also be stripped if configured to do so: ([PR #435](https://github.com/alphagov/govuk_frontend_toolkit/pull/435)).

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -249,3 +249,22 @@ initialize time as follows:
 
 Any value other than the JS literal `true` for `stripPostcodePII` will leave
 the analytics module configured not to strip postcodes.
+
+#### Avoding false positives
+
+Sometimes you will have data you want to send to analytics that looks like PII
+and would be stripped out.  For example on GOV.UK the content_ids that belong
+to every document can sometimes contain a string of characters that look like a
+UK postcode: in `eed5b92e-8279-4ca9-a141-5c35ed22fcf1` the substring `c35ed` in
+the final portion looks like a postcode, `C3 5ED`, and will be transformed into
+`eed5b92e-8279-4ca9-a141-5[postcode]22fcf1` which breaks the `content_id`.  To
+send data that you know is not PII, but it looks like an email address or a UK
+postcode you can provide your arguments wrapped in a `GOVUK.Analytics.PIISafe`
+object.  If any argument to an analytics function is an instance of one of these
+objects the value contained within will be extracted and sent directly to the
+analytics tracker without attempting to strip PII from it.  For example:
+
+```js
+  GOVUK.analytics.setDimension(1, new GOVUK.Analytics.PIISafe('this-is-not-an@email-address-but-it-looks-like-one'));
+  GOVUK.analytics.trackEvent('report title clicked', new GOVUK.Analytics.PIISafe('this report title looks like it contains a P0 5TC ode but it does not really'));
+````

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -29,6 +29,11 @@
     }
   }
 
+  var PIISafe = function (value) {
+    this.value = value
+  }
+  Analytics.PIISafe = PIISafe
+
   Analytics.prototype.stripPII = function (value) {
     if (typeof value === 'string') {
       return this.stripPIIFromString(value)
@@ -51,12 +56,16 @@
   }
 
   Analytics.prototype.stripPIIFromObject = function (object) {
-    for (var property in object) {
-      var value = object[property]
+    if (object instanceof Analytics.PIISafe) {
+      return object.value
+    } else {
+      for (var property in object) {
+        var value = object[property]
 
-      object[property] = this.stripPII(value)
+        object[property] = this.stripPII(value)
+      }
+      return object
     }
-    return object
   }
 
   Analytics.prototype.stripPIIFromArray = function (array) {

--- a/javascripts/govuk/analytics/analytics.js
+++ b/javascripts/govuk/analytics/analytics.js
@@ -37,7 +37,7 @@
   Analytics.prototype.stripPII = function (value) {
     if (typeof value === 'string') {
       return this.stripPIIFromString(value)
-    } else if (Object.prototype.toString.call(value) === '[object Array]') {
+    } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
       return this.stripPIIFromArray(value)
     } else if (typeof value === 'object') {
       return this.stripPIIFromObject(value)


### PR DESCRIPTION
For: https://trello.com/c/vISRi8lY/58-investigate-preventing-pii-being-sent-to-ga

This wrapper object can be used to wrap arguments we want to send to
analytics that we know are not PII because we generated them, but we also
know may look like PII.  Wrapping this kind of value in a `PIISafe` object
tells the analytics PII stripping code that this value is already safe and
instead of attempting to detect and remove PII from it, instead we should
extract the raw value and pass that on.

We realised we needed this because when testing smart-answers on GOV.UK
we noticed that the value of a custom dimension containing the content_ids
of the taxons for the smart-answer had been stripped.  The value of the
custom dimension was `eed5b92e-8279-4ca9-a141-5c35ed22fcf1`, but it was
transformed into `eed5b92e-8279-4ca9-a141-5[postcode]22fcf1` because the
substring `c35ed` in the final portion looks like a postcode, `C3 5ED`. To
avoid this we'd like to be able to tell analytics that some values are
definitely safe to send as they don't contain PII.

My first thought was to provide a list of tracker methods and values that
should be ignored.  Something like:

    GOVUK.Analytics.safe_for_PII = [['setdimension', 1]]

This would tell GOVUK.Analytics that for any arguments that start with
'setdimension' and 1 we should assume the other values are safe for PII.
However, it felt like the PII code would need to know too much about the
values it is given in order to work on this.  We'd also need to consider
how to say that the first value argument for a function was safe, but we
should still detect PII in any of the other arguments.

Our second thought, and the version in this commit, was to allow
individual values in the arguments to be wrapped in a "safe" object that
the analytics code knows to ignore.  This is inspired by the rails
`html_safe` functionality used in ERB views.  Rails automatically pushes
all output in an ERB template through an html escaping routine.  If you
know that the output is already safe, because it's a string of html you've
generated in a helper for example, then you can flag it as html_safe to
tell rails not to escape it.