### PR TITLE
Remove deprecation message and replace with notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+
+- Remove the deprecation warning in javascripts/govuk/selection-buttons.js as it is coupled to a different project which is not always used with this gem.
 # 7.4.1
 
 - Use a path, not a full url, as the `defaultPathForTrackPageview` because our analytics trackers expect the explicit page param to be a path, not a url ([PR #451](https://github.com/alphagov/govuk_frontend_toolkit/pull/451)).  Analytics sent with 7.3.0 and 7.4.0 are broken without this fix.

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -1,12 +1,9 @@
-// DEPRECATED
-// This isn’t needed if you’re using GOV.UK Elements 3.0.0 or above
+// NOTICE
+// IF you are using GOV.UK Elements 3.0,0 or above then you do not need to use
+// this script anymore as it uses a pure CSS solution.
 
 ;(function (global) {
   'use strict'
-
-  if (window.console && window.console.warn) {
-    window.console.warn('Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.')
-  }
 
   var $ = global.jQuery
   var GOVUK = global.GOVUK || {}


### PR DESCRIPTION
On GOV.UK sites we see this console alert a heck of a lot particularly
in test environments (see example below from [publishing-e2e-tests][1]) - 
I dread to imagine how many bytes we're using to store it in various
CI logs.

Since this deprecation depends on a third party library that GOV.UK is
not fully utilising it doesn't seem to be particularly helpful as the
only way to get rid of it is to switch to using GOV.UK elements.
Therefore I think it's more helpful if this is switched from being a
deprecation to be a notice in the source code.

A nicer alternative would be if the condition that checked for console
also had means to check if GOV.UK elements was being used.

End to end tests example:

```
17:45:03 Upload attachments on Travel Advice Publisher
17:45:04 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:04 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:04 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05 Deprecation warning: Custom radio buttons and checkboxes (released in GOV.UK Elements 3.0.0) no longer require this JavaScript.
17:45:05   Publishing a manual
```

Addresses: https://github.com/alphagov/govuk_frontend_toolkit/issues/416

[1]: https://github.com/alphagov/publishing-e2e-tests