### PR TITLE
Strip the user's email address out of the location used by GA

### DIFF
--- a/javascripts/govuk/analytics/google-analytics-universal-tracker.js
+++ b/javascripts/govuk/analytics/google-analytics-universal-tracker.js
@@ -20,6 +20,10 @@
       sendToGa('set', 'displayFeaturesTask', null)
     }
 
+    function stripLocationPII () {
+      sendToGa('set', 'location', stripEmailAddressesFromString(window.location.href))
+    }
+
     // Support legacy cookieDomain param
     if (typeof fieldsObject === 'string') {
       fieldsObject = { cookieDomain: fieldsObject }
@@ -28,6 +32,7 @@
     configureProfile()
     anonymizeIp()
     disableAdTracking()
+    stripLocationPII()
   }
 
   GoogleAnalyticsUniversalTracker.load = function () {
@@ -158,6 +163,11 @@
     if (typeof global.ga === 'function') {
       global.ga.apply(global, arguments)
     }
+  }
+
+  function stripEmailAddressesFromString (string) {
+    var stripped = string.replace(/[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g, '[email]')
+    return stripped
   }
 
   GOVUK.GoogleAnalyticsUniversalTracker = GoogleAnalyticsUniversalTracker

--- a/spec/unit/analytics/google-analytics-universal-tracker.spec.js
+++ b/spec/unit/analytics/google-analytics-universal-tracker.spec.js
@@ -177,4 +177,11 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', '10'])
     })
   })
+
+  describe('when tracking all events', function () {
+    window.history.replaceState(null, null, '?address=an.email@digital.cabinet-office.gov.uk')
+    it('removes any email address from the location', function () {
+      expect(window.ga.calls.mostRecent().args[2]).toContain('address=[email]')
+    })
+  })
 })


### PR DESCRIPTION
We have seen some paths in Google Analytics that include the user's email address, normally as part of the query string.  These URLs always have zero pageviews, but a number of hits (GA measures hit as any activity, e.g. event, timing measurement, etc).

Although there is existing code in this repo to strip personal information (PII) from the path, there are some cases where GA generates a new request (e.g. page timings) that we have not covered.  In this case, it reports the actual URL rather than our custom path.  This aligns with the observation of these hits having no pageviews, since pageviews are already stripped of this information.

This PR addresses that problem by stripping email addresses out of all URLs and setting this as a global location for GA to use on all requests from that page.

https://trello.com/c/jKitCyZI/311-remove-emails-from-ga-events-on-email-alert-frontend-pages