### PR TITLE
Do not suggest using the deprecated component installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,6 @@ With Django you can use https://github.com/jrief/django-sass-processor to compil
 
 Note: if you need complete styles you might want to install govuk-elements-sass package that also installs toolkit
 
-### Composer
-
-[govuk_frontend_toolkit_composer][toolkit_composer_github] is an composer package that can be
-[added to your composer.json][toolkit_composer_github_usage]
-
-[toolkit_composer_github]: https://github.com/PurpleBooth/govuk_frontend_toolkit_composer
-[toolkit_composer_github_usage]: https://github.com/PurpleBooth/govuk_frontend_toolkit_composer#installing
-
 ### Other projects
 
 #### Using the tagged versions


### PR DESCRIPTION
The recommendation for modern PHP/Symfony based projects is to use javascript tools to install javascript dependencies.

The component installer used by the previously suggested PurpleBooth/govuk_frontend_toolkit_composer package is deprecated: https://github.com/RobLoach/component-installer