### PR TITLE
🚧 Add tracking to see which JavaScript is being used and where

### DIFF
--- a/javascripts/govuk/details.polyfill.js
+++ b/javascripts/govuk/details.polyfill.js
@@ -6,7 +6,7 @@
 
 // http://www.sitepoint.com/fixing-the-details-element/
 
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}
@@ -234,6 +234,13 @@
     init: function ($container) {
       GOVUK.details.addEvent(document, 'DOMContentLoaded', GOVUK.details.addDetailsPolyfill)
       GOVUK.details.addEvent(window, 'load', GOVUK.details.addDetailsPolyfill)
+
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'details.polyfill.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
     }
   }
   global.GOVUK = GOVUK

--- a/javascripts/govuk/modules.js
+++ b/javascripts/govuk/modules.js
@@ -1,4 +1,4 @@
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -23,6 +23,13 @@
     },
 
     start: function (container) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'modules.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       var modules = this.find(container)
 
       for (var i = 0, l = modules.length; i < l; i++) {

--- a/javascripts/govuk/modules/auto-track-event.js
+++ b/javascripts/govuk/modules/auto-track-event.js
@@ -1,4 +1,4 @@
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var GOVUK = global.GOVUK || {}
@@ -6,6 +6,13 @@
 
   GOVUK.Modules.AutoTrackEvent = function () {
     this.start = function (element) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'auto-track-event.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       var options = { nonInteraction: 1 } // automatic events shouldn't affect bounce rate
       var category = element.data('track-category')
       var action = element.data('track-action')

--- a/javascripts/govuk/primary-links.js
+++ b/javascripts/govuk/primary-links.js
@@ -1,4 +1,4 @@
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -47,6 +47,13 @@
 
   GOVUK.primaryLinks = {
     init: function (selector) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'primary-links.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       $(selector).parent().each(function (i, el) {
         new GOVUK.PrimaryList(el, selector) // eslint-disable-line no-new
       })

--- a/javascripts/govuk/selection-buttons.js
+++ b/javascripts/govuk/selection-buttons.js
@@ -9,6 +9,13 @@
   var GOVUK = global.GOVUK || {}
 
   var SelectionButtons = function (elmsOrSelector, opts) {
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      GOVUK.analytics.trackEvent('Toolkit', 'selection-buttons.js', {
+        label: window.location.pathname,
+        nonInteraction: true
+      })
+    }
+
     this.selectedClass = 'selected'
     this.focusedClass = 'focused'
     this.radioClass = 'selection-button-radio'

--- a/javascripts/govuk/shim-links-with-button-role.js
+++ b/javascripts/govuk/shim-links-with-button-role.js
@@ -7,7 +7,7 @@
 //
 // Usage instructions:
 // GOVUK.shimLinksWithButtonRole.init();
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -16,6 +16,13 @@
   GOVUK.shimLinksWithButtonRole = {
 
     init: function init () {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'shim-links-with-button-role.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       // listen to 'document' for keydown event on the any elements that should be buttons.
       $(document).on('keydown', '[role="button"]', function (event) {
         // if the keyCode (which) is 32 it's a space, let's simulate a click.

--- a/javascripts/govuk/show-hide-content.js
+++ b/javascripts/govuk/show-hide-content.js
@@ -1,4 +1,4 @@
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -157,6 +157,13 @@
   }
 
   ShowHideContent.prototype.init = function ($container) {
+    if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+      GOVUK.analytics.trackEvent('Toolkit', 'show-hide-content.js', {
+        label: window.location.pathname,
+        nonInteraction: true
+      })
+    }
+
     this.showHideRadioToggledContent($container)
     this.showHideCheckboxToggledContent($container)
   }

--- a/javascripts/govuk/stick-at-top-when-scrolling.js
+++ b/javascripts/govuk/stick-at-top-when-scrolling.js
@@ -1,4 +1,4 @@
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -26,6 +26,13 @@
       return $el.offset()
     },
     init: function () {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'stick-at-the-top-when-scrolling.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       var $els = $('.js-stick-at-top-when-scrolling')
 
       if ($els.length > 0) {

--- a/javascripts/govuk/stop-scrolling-at-footer.js
+++ b/javascripts/govuk/stop-scrolling-at-footer.js
@@ -10,7 +10,7 @@
 // Height is passed in separatly incase the scrolling element has no height
 // itself.
 
-;(function (global) {
+; (function (global) {
   'use strict'
 
   var $ = global.jQuery
@@ -23,6 +23,13 @@
     _els: [],
 
     addEl: function ($fixedEl, height) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'stop-scrolling-at-footer.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       var fixedOffset
 
       if (!$fixedEl.length) { return }

--- a/javascripts/govuk_toolkit.js
+++ b/javascripts/govuk_toolkit.js
@@ -1,1 +1,11 @@
 // = require_tree ./govuk
+
+(function () {
+  if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+    GOVUK.analytics.trackEvent('Toolkit', 'govuk_toolkit.js', {
+      label: window.location.pathname,
+      nonInteraction: true
+    })
+  }
+}
+)()

--- a/javascripts/stageprompt.js
+++ b/javascripts/stageprompt.js
@@ -39,6 +39,13 @@
     }
 
     setup = function (analyticsCallback) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent('Toolkit', 'stageprompt.js', {
+          label: window.location.pathname,
+          nonInteraction: true
+        })
+      }
+
       var journeyStage = $('[data-journey]').attr('data-journey')
       var journeyHelpers = $('[data-journey-click]')
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "lint": "standard && bundle && bundle exec govuk-lint-sass stylesheets"
   },
   "standard": {
+    "globals": [
+      "GOVUK"
+    ],
     "ignore": [
       "/javascripts/vendor/",
       "/spec/support/"


### PR DESCRIPTION
 - Adding a Google Analytics event to see where, if anywhere, these JavaScript
   modules are being used.
 - Respects the user's settings by checking for the presences of the Google
   Analytics object - this won't be present if a user hasn't opted into
   tracking.